### PR TITLE
Move connection management into config node

### DIFF
--- a/nodes/config.js
+++ b/nodes/config.js
@@ -1,9 +1,12 @@
 /**
  * GoodWe Configuration Node
- * 
+ *
  * Shared configuration for GoodWe inverter connection settings.
- * This node stores connection details and manages connection lifecycle.
+ * This node stores connection details, owns the ProtocolHandler,
+ * and manages the connection lifecycle for all dependent nodes.
  */
+
+const { ProtocolHandler } = require("../lib/protocol.js");
 
 module.exports = function(RED) {
     "use strict";
@@ -14,7 +17,8 @@ module.exports = function(RED) {
      */
     function GoodWeConfigNode(config) {
         RED.nodes.createNode(this, config);
-        
+        const self = this;
+
         // Store configuration
         this.host = config.host;
         this.port = config.port || 8899;
@@ -23,38 +27,83 @@ module.exports = function(RED) {
         this.timeout = config.timeout || 1000;
         this.retries = config.retries || 3;
         this.commAddr = config.commAddr || "auto";
-        this.keepAlive = config.keepAlive === undefined ? true : config.keepAlive; // Default to true
-        
+        this.keepAlive = config.keepAlive === undefined ? true : config.keepAlive;
+
         // Connection state
-        this.connection = null;
-        this.isConnected = false;
-        
+        this.protocolHandler = null;
+        this.users = [];
+
         /**
          * Get connection configuration
          * @returns {Object} Connection configuration object
          */
         this.getConfig = function() {
             return {
-                host: this.host,
-                port: this.port,
-                protocol: this.protocol,
-                family: this.family,
-                timeout: this.timeout,
-                retries: this.retries,
-                commAddr: this.commAddr,
-                keepAlive: this.keepAlive
+                host: self.host,
+                port: self.port,
+                protocol: self.protocol,
+                family: self.family,
+                timeout: self.timeout,
+                retries: self.retries,
+                commAddr: self.commAddr,
+                keepAlive: self.keepAlive
             };
         };
-        
+
+        /**
+         * Get or create the shared ProtocolHandler instance.
+         * The handler is created lazily on first call.
+         * @returns {Object} ProtocolHandler instance
+         */
+        this.getProtocolHandler = function() {
+            if (!self.protocolHandler) {
+                self.protocolHandler = new ProtocolHandler({
+                    host: self.host,
+                    port: self.port,
+                    protocol: self.protocol,
+                    family: self.family,
+                    timeout: self.timeout || 1000,
+                    retries: self.retries || 3,
+                    commAddr: self.commAddr
+                });
+
+                // Forward events to registered user nodes
+                self.protocolHandler.on("status", (status) => {
+                    self.users.forEach(node => node.emit("goodwe:status", status));
+                });
+                self.protocolHandler.on("error", (err) => {
+                    self.users.forEach(node => node.emit("goodwe:error", err));
+                });
+            }
+            return self.protocolHandler;
+        };
+
+        /**
+         * Register a dependent node
+         * @param {Object} node - Node-RED node instance
+         */
+        this.registerUser = function(node) {
+            self.users.push(node);
+        };
+
+        /**
+         * Deregister a dependent node
+         * @param {Object} node - Node-RED node instance
+         */
+        this.deregisterUser = function(node) {
+            self.users = self.users.filter(u => u.id !== node.id);
+        };
+
         /**
          * Cleanup on node close
          */
-        this.on("close", function(done) {
-            // Close any active connections
-            if (this.connection) {
-                this.connection = null;
+        this.on("close", async function(done) {
+            // Disconnect the protocol handler
+            if (self.protocolHandler) {
+                await self.protocolHandler.disconnect();
+                self.protocolHandler = null;
             }
-            this.isConnected = false;
+            self.users = [];
             done();
         });
     }


### PR DESCRIPTION
## Summary
- Config node now owns a shared `ProtocolHandler` instance via lazy `getProtocolHandler()` singleton
- Read node uses the config node's shared handler instead of creating its own `ProtocolHandler`
- Config node tracks dependent nodes with `registerUser()`/`deregisterUser()` and forwards protocol status/error events
- Connection lifecycle tied to config node — disconnect happens on config node close, not individual read node close

Closes #34

## Test plan
- [x] All 339 tests pass
- [x] No lint errors
- [x] Config node tests verify singleton handler, user tracking, and cleanup on close
- [x] Read node tests still pass with shared handler pattern
- [ ] Verify with real inverter (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)