### PR TITLE
Fix discover cleanup race on Node 24+ (Not running on close of unbound socket)

### DIFF
--- a/lib/protocol.js
+++ b/lib/protocol.js
@@ -511,9 +511,19 @@ function discoverInverters(options = {}) {
         const discoveredInverters = [];
         const socket = dgram.createSocket("udp4");
 
+        let cleanedUp = false;
         const cleanup = () => {
+            if (cleanedUp) return;
+            cleanedUp = true;
             socket.removeAllListeners();
-            socket.close();
+            // Node 24+'s dgram throws "Not running" when close() is called on
+            // an unbound socket — which happens if send() errors before bind()
+            // completes (e.g. broadcastAddress fails DNS resolution).
+            try {
+                socket.close();
+            } catch (_err) {
+                // Already closed or never bound — nothing to release.
+            }
         };
 
         const timeoutId = setTimeout(() => {

--- a/test/connectivity.test.js
+++ b/test/connectivity.test.js
@@ -386,6 +386,29 @@ describe("discovery helper functions", () => {
         }
     });
 
+    it("should not throw 'Not running' when send fails before bind completes", async () => {
+        // Regression: lib/protocol.js cleanup() previously called socket.close()
+        // unconditionally. On Node 24+, dgram.close() throws "Not running" when
+        // called on an unbound socket — which happens when send() errors out
+        // (e.g. DNS resolution failure on an invalid broadcast address) before
+        // bind() finishes. The cleanup should be idempotent and tolerate an
+        // already-closed or never-bound socket.
+        let caught;
+        try {
+            await discoverInverters({
+                timeout: 100,
+                broadcastAddress: "invalid"
+            });
+        } catch (err) {
+            caught = err;
+        }
+        // The promise must settle one way or the other — what we explicitly do
+        // NOT want is the process crashing on an uncaught "Not running" throw.
+        if (caught) {
+            expect(caught.message).not.toContain("Not running");
+        }
+    });
+
     it("should parse device info from AA55 payload", () => {
         // Build a mock device info payload
         const payload = Buffer.alloc(53);


### PR DESCRIPTION
## Summary
Follow-up to #83. After that merge, post-merge CI flaked on Node 24.x in `test/discover-node.test.js › error handling › should handle discovery errors gracefully` with:

```
Not running
  at close (lib/protocol.js:516:20)
  at cleanup (lib/protocol.js:556:25)
```

## Root cause
`discoverInverters` cleanup called `socket.close()` unconditionally. When the discover node is given a bad `broadcastAddress` (e.g. `"invalid"` as in the regression test), `socket.send()` errors out before `bind()` has fully completed. On Node 24+, `dgram.close()` on an unbound socket throws `Not running` — older Node versions silently no-op. The throw is uncaught and propagates as a Jest test failure.

This is a latent pre-existing bug unrelated to PR #83. PR #83's CI happened to win the race on the pre-merge run for all 4 Node versions; the post-merge CI on `main` lost the race on the 24.x runner.

Related to #58 (socket error paths) and #78 (discoverInverters silent failures).

## Fix
- Mark `cleanup()` idempotent with a `cleanedUp` flag so double-call (timeout + send-error) is a no-op.
- Wrap `socket.close()` in `try/catch` — closing an already-closed or never-bound socket is not an error worth surfacing.

## Test plan
- [x] `npm test` — 279 tests pass (added 1 regression test)
- [x] `npm run lint` — clean (2 pre-existing warnings tracked by #57)
- [x] New test `should not throw 'Not running' when send fails before bind completes` calls `discoverInverters` directly with `broadcastAddress: "invalid"` and asserts the promise settles without crashing.
- [ ] CI green on all 4 Node versions (20/22/24/26)
- [ ] Post-merge CI green on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)