### PR TITLE
Serialize sendCommand() per ProtocolHandler instance (#56)

### DIFF
--- a/lib/protocol.js
+++ b/lib/protocol.js
@@ -34,6 +34,12 @@ class ProtocolHandler extends EventEmitter {
         this.consecutiveFailures = 0;
         this.lastError = null;
 
+        // FIFO queue tail for serializing in-flight sendCommand() calls. UDP
+        // responses are matched by arrival order (no transaction ID) and TCP
+        // framing assumes one request in flight; concurrent callers against
+        // the same handler would race on the shared socket listener.
+        this._inflight = null;
+
         // Resolve comm address
         this._commAddr = this.config.commAddr === "auto"
             ? modbus.getDefaultCommAddr(this.config.family)
@@ -177,12 +183,32 @@ class ProtocolHandler extends EventEmitter {
     }
 
     /**
-     * Send a command and wait for response
+     * Send a command and wait for response.
+     *
+     * Serialized per-handler: if another sendCommand() is already in flight,
+     * this call queues behind it and runs only once the previous one settles.
+     * This prevents UDP/TCP response handlers from racing on the shared socket
+     * when multiple worker nodes share the same config-node ProtocolHandler.
+     *
      * @param {Buffer} command - Command buffer to send
      * @param {number} expectedLength - Expected response length (optional)
      * @returns {Promise<Buffer>}
      */
     sendCommand(command, expectedLength = null) {
+        const exec = () => this._sendCommandImpl(command, expectedLength);
+        // Chain regardless of whether the prior call resolved or rejected; a
+        // failure must not poison subsequent callers.
+        const next = (this._inflight || Promise.resolve()).then(exec, exec);
+        this._inflight = next.catch(() => {});
+        return next;
+    }
+
+    /**
+     * Underlying socket-level send/receive. Not safe to call concurrently
+     * against the same handler — invoke via sendCommand() which serializes.
+     * @private
+     */
+    _sendCommandImpl(command, expectedLength = null) {
         return new Promise((resolve, reject) => {
             if (!this.socket) {
                 reject(new Error("Not connected"));

--- a/test/connectivity.test.js
+++ b/test/connectivity.test.js
@@ -177,14 +177,14 @@ describe("ProtocolHandler", () => {
         });
 
         it("should timeout if no response received", async () => {
-            const handler = new ProtocolHandler({ 
+            const handler = new ProtocolHandler({
                 protocol: "udp",
                 timeout: 100,
                 host: "192.168.255.255" // Invalid host to ensure timeout
             });
-            
+
             await handler.connect();
-            
+
             try {
                 await handler.sendCommand(Buffer.from([0x00]));
                 throw new Error("Should have timed out");
@@ -192,8 +192,65 @@ describe("ProtocolHandler", () => {
                 // May get TIMEOUT or EPERM depending on environment
                 expect(["TIMEOUT", "EPERM"]).toContain(err.code);
             }
-            
+
             await handler.disconnect();
+        });
+
+        it("should serialize concurrent sendCommand() calls (no overlap)", async () => {
+            // Regression for #56: when multiple worker nodes share a handler,
+            // concurrent sendCommand() calls must run one at a time so UDP/TCP
+            // responses are not interleaved on the shared socket listener.
+            const handler = new ProtocolHandler({ protocol: "udp" });
+
+            const callLog = [];
+            let active = 0;
+            let maxConcurrent = 0;
+
+            // Replace the inner impl with a controllable stub. The queue logic
+            // is in sendCommand(); we exercise it directly without sockets.
+            handler._sendCommandImpl = async (cmd) => {
+                const id = cmd[0];
+                callLog.push(`start:${id}`);
+                active++;
+                maxConcurrent = Math.max(maxConcurrent, active);
+                // Yield several ticks so any racing caller would overlap.
+                await new Promise(r => setTimeout(r, 10));
+                active--;
+                callLog.push(`end:${id}`);
+                return Buffer.from([id]);
+            };
+
+            const results = await Promise.all([
+                handler.sendCommand(Buffer.from([1])),
+                handler.sendCommand(Buffer.from([2])),
+                handler.sendCommand(Buffer.from([3]))
+            ]);
+
+            expect(maxConcurrent).toBe(1);
+            expect(callLog).toEqual([
+                "start:1", "end:1",
+                "start:2", "end:2",
+                "start:3", "end:3"
+            ]);
+            expect(results.map(b => b[0])).toEqual([1, 2, 3]);
+        });
+
+        it("should continue serving subsequent calls after one rejects", async () => {
+            // Failures must not poison the queue.
+            const handler = new ProtocolHandler({ protocol: "udp" });
+
+            let calls = 0;
+            handler._sendCommandImpl = async () => {
+                calls++;
+                if (calls === 1) throw new Error("simulated failure");
+                return Buffer.from([calls]);
+            };
+
+            const first = handler.sendCommand(Buffer.from([0]));
+            const second = handler.sendCommand(Buffer.from([0]));
+
+            await expect(first).rejects.toThrow("simulated failure");
+            await expect(second).resolves.toEqual(Buffer.from([2]));
         });
     });
 


### PR DESCRIPTION
## Summary
Closes #56 (critical). The shared `ProtocolHandler` had no request queue — when multiple worker nodes shared one config, concurrent `sendCommand()` calls raced on the socket because UDP responses are matched by arrival order (no transaction ID) and TCP framing assumed a single in-flight request.

## Fix
Add a per-handler FIFO promise chain (`_inflight`) that serializes `sendCommand()` calls:
- Public `sendCommand()` becomes a thin wrapper that chains the body onto the prior call via `.then(exec, exec)` — fulfilment and rejection both advance the queue.
- The actual body moves to `_sendCommandImpl` (private).
- `this._inflight = next.catch(() => {})` prevents one rejection from poisoning the chain; the original caller still sees the rejection via the returned `next`.

## Test plan
- [x] `npm test` — 281 tests pass (added 2):
  - `should serialize concurrent sendCommand() calls (no overlap)`: 3 concurrent calls with a 10 ms inner stub; verifies `maxConcurrent === 1` and ordering preserved.
  - `should continue serving subsequent calls after one rejects`: first call rejects, second resolves cleanly.
- [x] `npm run lint` — clean (2 pre-existing warnings tracked by #57)
- [ ] CI green on all 4 Node versions

## Self-review (4 perspectives)
- **Quality**: clean method split; JSDoc explains contract; silent `.catch()` intentional and commented.
- **Architecture**: per-instance state, no new public API, mutex at the right layer (library, not per-worker).
- **Security**: response-matching races no longer possible — slight defensive win.
- **Error handling**: queue keeps advancing on rejection; tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)