### PR TITLE
Filter spoofed LAN discovery responses (#61)

### DIFF
--- a/lib/protocol.js
+++ b/lib/protocol.js
@@ -7,10 +7,59 @@
 
 const dgram = require("dgram");
 const net = require("net");
+const os = require("os");
 const EventEmitter = require("events");
 const { getFamilyConfig, parseSensorData } = require("./sensors");
 const modbus = require("./modbus");
 const { enhanceError } = require("./errors");
+
+/**
+ * Convert a dotted-quad IPv4 string to a 32-bit unsigned integer (big-endian).
+ * Returns null for input that isn't a valid IPv4 literal.
+ * @param {string} ip
+ * @returns {number|null}
+ */
+function ipv4ToInt(ip) {
+    if (typeof ip !== "string") return null;
+    const parts = ip.split(".");
+    if (parts.length !== 4) return null;
+    let n = 0;
+    for (const p of parts) {
+        const v = Number(p);
+        if (!Number.isInteger(v) || v < 0 || v > 255 || /\D/.test(p)) return null;
+        n = (n * 256) + v;
+    }
+    // Force unsigned 32-bit.
+    return n >>> 0;
+}
+
+/**
+ * Return true when `ipAddress` shares a subnet with any non-internal IPv4
+ * interface on this host, or is loopback. Used to filter spoofed discovery
+ * responses arriving from outside the local L2 segment.
+ *
+ * Defaults to false on parse errors so callers fail closed.
+ * @param {string} ipAddress
+ * @returns {boolean}
+ */
+function isLocalSubnet(ipAddress) {
+    const peer = ipv4ToInt(ipAddress);
+    if (peer === null) return false;
+    // Loopback /8 — always trust.
+    if ((peer & 0xFF000000) >>> 0 === 0x7F000000) return true;
+    const ifaces = os.networkInterfaces();
+    for (const list of Object.values(ifaces)) {
+        if (!list) continue;
+        for (const iface of list) {
+            if (iface.family !== "IPv4" || iface.internal) continue;
+            const local = ipv4ToInt(iface.address);
+            const mask = ipv4ToInt(iface.netmask);
+            if (local === null || mask === null) continue;
+            if (((local & mask) >>> 0) === ((peer & mask) >>> 0)) return true;
+        }
+    }
+    return false;
+}
 
 /**
  * Protocol Handler for GoodWe Inverters
@@ -528,12 +577,18 @@ function parseDeviceInfo(payload) {
  * @param {Object} options - Discovery options
  * @param {number} options.timeout - Discovery timeout in ms (default: 5000)
  * @param {string} options.broadcastAddress - Broadcast address (default: 255.255.255.255)
+ * @param {boolean} options.acceptAnySource - When true, skip the local-subnet
+ *   source-IP filter and accept discovery responses from any host. Default
+ *   false. Only enable for routed setups where the inverter is reachable but
+ *   not on the same L2 segment as the Node-RED host (you are then responsible
+ *   for the trust boundary).
  * @returns {Promise<Array>} Array of discovered inverters
  */
 function discoverInverters(options = {}) {
     return new Promise((resolve, reject) => {
         const timeout = options.timeout || 5000;
         const broadcastAddress = options.broadcastAddress || "255.255.255.255";
+        const acceptAnySource = options.acceptAnySource === true;
         const discoveredInverters = [];
         const socket = dgram.createSocket("udp4");
 
@@ -565,14 +620,26 @@ function discoverInverters(options = {}) {
 
         socket.on("message", (msg, rinfo) => {
             try {
-                // Parse AA55 discovery response
-                if (msg.length > 6 && msg[0] === 0xAA && msg[1] === 0x55) {
-                    const inverter = parseDiscoveryResponse(msg, rinfo.address);
-                    if (inverter) {
-                        const exists = discoveredInverters.some(inv => inv.ip === inverter.ip);
-                        if (!exists) {
-                            discoveredInverters.push(inverter);
-                        }
+                // (1) Trust boundary: reject sources outside our local subnet
+                // unless the caller explicitly opted out. AA55 has no auth, so
+                // any LAN host that knows the protocol can advertise itself.
+                if (!acceptAnySource && !isLocalSubnet(rinfo.address)) {
+                    // Drop silently — tracking rejected sources is #78's scope.
+                    return;
+                }
+                // (2) Validate AA55 framing (magic bytes + length + 16-bit
+                // checksum) before parsing. validateAA55Response would also
+                // check an expected response type, but discovery uses a fixed
+                // command so we only need structural validity here.
+                const validation = modbus.validateAA55Response(msg);
+                if (!validation.valid) {
+                    return;
+                }
+                const inverter = parseDiscoveryResponse(msg, rinfo.address);
+                if (inverter) {
+                    const exists = discoveredInverters.some(inv => inv.ip === inverter.ip);
+                    if (!exists) {
+                        discoveredInverters.push(inverter);
                     }
                 }
             } catch (err) {
@@ -662,4 +729,7 @@ module.exports = {
     ProtocolHandler,
     discoverInverters,
     parseDeviceInfo,
+    // Exported for unit tests; not part of the public Node-RED API.
+    isLocalSubnet,
+    ipv4ToInt,
 };

--- a/test/connectivity.test.js
+++ b/test/connectivity.test.js
@@ -466,6 +466,47 @@ describe("discovery helper functions", () => {
         }
     });
 
+    describe("source-IP filtering (#61)", () => {
+        const { isLocalSubnet, ipv4ToInt } = require("../lib/protocol.js");
+
+        it("ipv4ToInt parses valid dotted-quad addresses", () => {
+            expect(ipv4ToInt("0.0.0.0")).toBe(0);
+            expect(ipv4ToInt("127.0.0.1")).toBe(0x7F000001);
+            expect(ipv4ToInt("192.168.1.100")).toBe(0xC0A80164);
+            expect(ipv4ToInt("255.255.255.255")).toBe(0xFFFFFFFF >>> 0);
+        });
+
+        it("ipv4ToInt rejects malformed input", () => {
+            expect(ipv4ToInt("")).toBeNull();
+            expect(ipv4ToInt("not-an-ip")).toBeNull();
+            expect(ipv4ToInt("1.2.3")).toBeNull();
+            expect(ipv4ToInt("1.2.3.4.5")).toBeNull();
+            expect(ipv4ToInt("256.0.0.1")).toBeNull();
+            expect(ipv4ToInt("-1.0.0.0")).toBeNull();
+            expect(ipv4ToInt("1.2.3.4 ")).toBeNull(); // trailing space → NaN per part
+            expect(ipv4ToInt(null)).toBeNull();
+            expect(ipv4ToInt(undefined)).toBeNull();
+        });
+
+        it("isLocalSubnet accepts loopback addresses", () => {
+            expect(isLocalSubnet("127.0.0.1")).toBe(true);
+            expect(isLocalSubnet("127.255.255.254")).toBe(true);
+        });
+
+        it("isLocalSubnet rejects clearly remote addresses", () => {
+            // These are public IPs unlikely to be in any test host's local
+            // subnet. Anchored by RFC 6890 / IANA allocations.
+            expect(isLocalSubnet("8.8.8.8")).toBe(false);
+            expect(isLocalSubnet("1.1.1.1")).toBe(false);
+        });
+
+        it("isLocalSubnet returns false for malformed input (fail-closed)", () => {
+            expect(isLocalSubnet("")).toBe(false);
+            expect(isLocalSubnet("not-an-ip")).toBe(false);
+            expect(isLocalSubnet(null)).toBe(false);
+        });
+    });
+
     it("should parse device info from AA55 payload", () => {
         // Build a mock device info payload
         const payload = Buffer.alloc(53);


### PR DESCRIPTION
## Summary
Closes #61 (high/security). The discovery UDP socket accepted AA55 packets from any LAN host with no source-IP filter and no frame validation. Any LAN-resident attacker who knows the (public) protocol could advertise itself as a GoodWe inverter, and a user might paste that IP into goodwe-config, redirecting subsequent control commands to the attacker.

## Fix
Two-stage filter in `discoverInverters`' message handler:
1. **Source-IP**: reject responses from outside the local subnet by default (`isLocalSubnet(rinfo.address)`). Compares peer IP against every non-internal IPv4 interface's `(address, netmask)` pair. Loopback is always trusted; malformed input fails closed.
2. **AA55 frame validation**: `validateAA55Response(msg)` (length + magic bytes + 16-bit checksum) must pass before `parseDiscoveryResponse` runs.

Opt-out: `options.acceptAnySource: true` for routed setups where the inverter is reachable but not L2-local. Documented inline with the trust-boundary caveat.

Defense in depth — the unkeyed AA55 checksum can be forged by anyone with the public protocol spec, but combined with the source-IP filter, an off-subnet attacker is blocked regardless of payload validity.

## Test plan
- [x] `npm test` — 286 pass (added 5):
  - `ipv4ToInt` parses valid dotted-quad, returns null on malformed
  - `isLocalSubnet` accepts loopback, rejects 8.8.8.8/1.1.1.1, fail-closed on bad input
- [x] `npm run lint` — clean
- [ ] CI green on 4 Node versions
- [ ] Post-merge CI green on main

## Self-review (4 perspectives)
- **Quality**: pure helpers with JSDoc; inline comments explain the two-stage check; opted not to surface `rejectedSources` (deferred to #78).
- **Architecture**: helpers live in `lib/protocol.js` (could move to a future `lib/discovery.js` per #80); resolved-value shape unchanged so the discover node stays compatible.
- **Security**: addresses the threat model directly; default-strict with documented opt-out; fail-closed semantics.
- **Error handling**: bad packets continue to be ignored silently (existing behavior); rejection is silent now too — diagnostics counter is #78's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)