### PR TITLE
Harden ProtocolHandler socket error paths (#58)

### DIFF
--- a/lib/protocol.js
+++ b/lib/protocol.js
@@ -89,6 +89,12 @@ class ProtocolHandler extends EventEmitter {
         // the same handler would race on the shared socket listener.
         this._inflight = null;
 
+        // Default no-op "error" listener so an emit("error", ...) before any
+        // user listener attaches does not crash the runtime (EventEmitter
+        // throws on unhandled "error" by default). Users adding their own
+        // listener still see every event — this is additive.
+        this.on("error", () => {});
+
         // Resolve comm address
         this._commAddr = this.config.commAddr === "auto"
             ? modbus.getDefaultCommAddr(this.config.family)
@@ -175,26 +181,42 @@ class ProtocolHandler extends EventEmitter {
 
             try {
                 this.socket = new net.Socket();
+                const socket = this.socket;
 
-                this.socket.on("connect", () => {
+                // Connect-phase error: rejects the connect() promise and
+                // attaches a long-lived listener via `once` so it fires at most
+                // once. After successful connect we explicitly remove it and
+                // attach the post-connect handler — calling reject() on an
+                // already-settled promise would be a no-op, and the unhandled
+                // emit("error") would crash the runtime.
+                const onConnectError = (err) => {
                     clearTimeout(timeout);
+                    this.lastError = err;
+                    this.consecutiveFailures++;
+                    this.emit("error", err);
+                    reject(enhanceError(err, this.config));
+                };
+                socket.once("error", onConnectError);
+
+                socket.once("connect", () => {
+                    clearTimeout(timeout);
+                    socket.removeListener("error", onConnectError);
+                    // Long-lived listener: just record + emit. Never rejects
+                    // a settled promise. Request-scoped listeners in
+                    // _sendCommandImpl fail in-flight reads.
+                    socket.on("error", (err) => {
+                        this.lastError = err;
+                        this.emit("error", err);
+                    });
                     resolve();
                 });
 
-                this.socket.on("error", (err) => {
-                    clearTimeout(timeout);
-                    this.emit("error", err);
-                    this.consecutiveFailures++;
-                    this.lastError = err;
-                    reject(enhanceError(err, this.config));
-                });
-
-                this.socket.on("close", () => {
+                socket.on("close", () => {
                     this.connected = false;
                     this.emit("status", { state: "disconnected" });
                 });
 
-                this.socket.connect(this.config.port, this.config.host);
+                socket.connect(this.config.port, this.config.host);
             } catch (err) {
                 clearTimeout(timeout);
                 reject(err);
@@ -263,68 +285,85 @@ class ProtocolHandler extends EventEmitter {
                 reject(new Error("Not connected"));
                 return;
             }
+            const socket = this.socket;
 
             let timeoutId;
+            let settled = false;
             let responseBuffer = Buffer.alloc(0);
+
+            // Request-scoped listeners. They are explicitly added and removed
+            // here (not via removeAllListeners) so the long-lived listeners
+            // attached by _connectTCP/_connectUDP keep working.
+            let onMessage, onData, onError, onClose;
 
             const cleanup = () => {
                 if (timeoutId) clearTimeout(timeoutId);
-                if (this.config.protocol === "udp") {
-                    this.socket.removeAllListeners("message");
-                } else {
-                    this.socket.removeAllListeners("data");
-                }
+                if (onMessage) socket.removeListener("message", onMessage);
+                if (onData) socket.removeListener("data", onData);
+                if (onError) socket.removeListener("error", onError);
+                if (onClose) socket.removeListener("close", onClose);
+            };
+
+            const settleReject = (err) => {
+                if (settled) return;
+                settled = true;
+                cleanup();
+                this.consecutiveFailures++;
+                reject(err);
+            };
+
+            const settleResolve = (value) => {
+                if (settled) return;
+                settled = true;
+                cleanup();
+                this.consecutiveFailures = 0;
+                resolve(value);
             };
 
             timeoutId = setTimeout(() => {
-                cleanup();
-                this.consecutiveFailures++;
                 const error = new Error("Response timeout");
                 error.code = "TIMEOUT";
-                reject(enhanceError(error, this.config));
+                settleReject(enhanceError(error, this.config));
             }, this.config.timeout);
 
-            if (this.config.protocol === "udp") {
-                this.socket.once("message", (msg) => {
-                    cleanup();
-                    this.consecutiveFailures = 0;
-                    resolve(msg);
-                });
+            // Surface socket-level errors during the request so the promise
+            // fails fast instead of hanging until timeout.
+            onError = (err) => settleReject(enhanceError(err, this.config));
+            socket.once("error", onError);
 
-                this.socket.send(command, this.config.port, this.config.host, (err) => {
-                    if (err) {
-                        cleanup();
-                        this.consecutiveFailures++;
-                        reject(err);
-                    }
+            if (this.config.protocol === "udp") {
+                onMessage = (msg) => settleResolve(msg);
+                socket.once("message", onMessage);
+
+                socket.send(command, this.config.port, this.config.host, (err) => {
+                    if (err) settleReject(err);
                 });
             } else {
-                const onData = (data) => {
+                onClose = () => {
+                    const err = new Error("Socket closed during request");
+                    err.code = "ECONNRESET";
+                    settleReject(enhanceError(err, this.config));
+                };
+                socket.once("close", onClose);
+
+                onData = (data) => {
                     responseBuffer = Buffer.concat([responseBuffer, data]);
 
                     // Check if we have received enough data
                     if (expectedLength && responseBuffer.length >= expectedLength) {
-                        cleanup();
-                        this.consecutiveFailures = 0;
-                        resolve(responseBuffer);
+                        settleResolve(responseBuffer);
                     } else if (!expectedLength) {
                         // For protocols without fixed length, wait a bit for all data
                         clearTimeout(timeoutId);
                         timeoutId = setTimeout(() => {
-                            cleanup();
-                            this.consecutiveFailures = 0;
-                            resolve(responseBuffer);
+                            settleResolve(responseBuffer);
                         }, 100);
                     }
                 };
+                socket.on("data", onData);
 
-                this.socket.on("data", onData);
-                this.socket.write(command, (err) => {
-                    if (err) {
-                        cleanup();
-                        this.consecutiveFailures++;
-                        reject(err);
-                    }
+                socket.write(command, (err) => {
+                    if (err) settleReject(err);
                 });
             }
         });

--- a/test/connectivity.test.js
+++ b/test/connectivity.test.js
@@ -235,6 +235,52 @@ describe("ProtocolHandler", () => {
             expect(results.map(b => b[0])).toEqual([1, 2, 3]);
         });
 
+        it("rejects fast when UDP socket emits 'error' mid-request (#58)", async () => {
+            const EventEmitter = require("events");
+            const handler = new ProtocolHandler({ protocol: "udp", timeout: 5000 });
+            const fake = new EventEmitter();
+            fake.send = () => { /* never invokes callback */ };
+            handler.socket = fake;
+
+            const pending = handler.sendCommand(Buffer.from([0x01]));
+            // Defer the error emit a tick so the request-scoped listener is
+            // attached first.
+            setImmediate(() => {
+                const e = new Error("ENETUNREACH");
+                e.code = "ENETUNREACH";
+                fake.emit("error", e);
+            });
+
+            await expect(pending).rejects.toThrow("ENETUNREACH");
+            expect(handler.consecutiveFailures).toBeGreaterThan(0);
+            // Long-lived listeners (if any) plus the constructor's default
+            // no-op should remain.
+            expect(fake.listenerCount("error")).toBe(0);
+        });
+
+        it("rejects fast when TCP socket emits 'close' mid-request (#58)", async () => {
+            const EventEmitter = require("events");
+            const handler = new ProtocolHandler({ protocol: "tcp", timeout: 5000 });
+            const fake = new EventEmitter();
+            fake.write = () => { /* never delivers data */ };
+            handler.socket = fake;
+
+            const pending = handler.sendCommand(Buffer.from([0x01]));
+            setImmediate(() => fake.emit("close"));
+
+            await expect(pending).rejects.toThrow(/closed during request/);
+            expect(fake.listenerCount("data")).toBe(0);
+            expect(fake.listenerCount("close")).toBe(0);
+            expect(fake.listenerCount("error")).toBe(0);
+        });
+
+        it("does not crash when 'error' is emitted with no user listener (#58)", () => {
+            const handler = new ProtocolHandler();
+            // No external listener attached. Emit should not throw — the
+            // constructor installed a default no-op consumer.
+            expect(() => handler.emit("error", new Error("transient"))).not.toThrow();
+        });
+
         it("should continue serving subsequent calls after one rejects", async () => {
             // Failures must not poison the queue.
             const handler = new ProtocolHandler({ protocol: "udp" });


### PR DESCRIPTION
## Summary
Closes #58 (high/error-handling). Three latent gaps in socket error handling fixed:

1. **No request-scoped error/close handlers in `_sendCommandImpl`** — UDP send errors and TCP mid-response disconnects (ECONNRESET) caused the promise to hang until timeout. Now: explicit `once(\"error\")` (UDP+TCP) and `once(\"close\")` (TCP) fail fast.

2. **`_connectTCP` post-connect crash hazard** — the connect-phase error listener stayed attached. Any later socket error called `reject()` on the already-settled connect promise (no-op) and then `this.emit(\"error\", err)` with no consumer, which Node throws on. Now: connect-phase listeners use `once`; on resolve they're swapped for a long-lived listener that only records + emits.

3. **No default error listener on the handler** — `emit(\"error\", ...)` before any user listener attaches crashed Node-RED. Constructor now installs `this.on(\"error\", () => {})` no-op consumer; user listeners are still called.

## Fix detail
- `_sendCommandImpl` rewritten with `settleResolve`/`settleReject` helpers and a `settled` guard. Listeners are removed by reference (no `removeAllListeners` — preserves the long-lived listeners installed by `_connect*`).

## Test plan
- [x] `npm test` — 289 pass (+3 new):
  - UDP socket emits \"error\" mid-request → rejects with the wrapped error, `consecutiveFailures` increments, listeners cleaned up.
  - TCP socket emits \"close\" mid-request → rejects with \"Socket closed during request\".
  - `emit(\"error\")` with no user listener doesn't crash.
- [x] `npm run lint` — clean
- [ ] CI green on 4 Node versions
- [ ] Post-merge CI green on main

## Self-review (4 perspectives)
- **Quality**: cleaner control flow; explicit listener references; one-line constructor change with clear comment.
- **Architecture**: listener-swap pattern is canonical Node net.Socket usage; no new module deps.
- **Security**: closes an uncaught-error DoS vector against the runtime.
- **Error handling**: the meat — UDP/TCP/emit-without-listener all covered with regression tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)