### PR TITLE
Enforce absolute deadline in sendCommand alongside idle timer (#59)

### DIFF
--- a/lib/protocol.js
+++ b/lib/protocol.js
@@ -9,6 +9,12 @@ const dgram = require("dgram");
 const net = require("net");
 const os = require("os");
 const EventEmitter = require("events");
+
+// When no expectedLength is supplied, TCP `_sendCommandImpl` resolves after
+// this many milliseconds of inactivity following the first byte. Short enough
+// to be responsive on real inverters, long enough to bridge frame fragmentation.
+// The *absolute* deadline (config.timeout) is enforced independently — see #59.
+const IDLE_BYTES_TIMEOUT_MS = 100;
 const { getFamilyConfig, parseSensorData } = require("./sensors");
 const modbus = require("./modbus");
 const { enhanceError } = require("./errors");
@@ -287,7 +293,8 @@ class ProtocolHandler extends EventEmitter {
             }
             const socket = this.socket;
 
-            let timeoutId;
+            let deadlineTimer;
+            let idleTimer;
             let settled = false;
             let responseBuffer = Buffer.alloc(0);
 
@@ -297,7 +304,8 @@ class ProtocolHandler extends EventEmitter {
             let onMessage, onData, onError, onClose;
 
             const cleanup = () => {
-                if (timeoutId) clearTimeout(timeoutId);
+                if (deadlineTimer) clearTimeout(deadlineTimer);
+                if (idleTimer) clearTimeout(idleTimer);
                 if (onMessage) socket.removeListener("message", onMessage);
                 if (onData) socket.removeListener("data", onData);
                 if (onError) socket.removeListener("error", onError);
@@ -320,7 +328,10 @@ class ProtocolHandler extends EventEmitter {
                 resolve(value);
             };
 
-            timeoutId = setTimeout(() => {
+            // Absolute deadline — never reset, even when data trickles in. A
+            // misbehaving peer that dribbles bytes every IDLE_BYTES_TIMEOUT_MS
+            // would otherwise keep the promise alive indefinitely (#59).
+            deadlineTimer = setTimeout(() => {
                 const error = new Error("Response timeout");
                 error.code = "TIMEOUT";
                 settleReject(enhanceError(error, this.config));
@@ -349,15 +360,19 @@ class ProtocolHandler extends EventEmitter {
                 onData = (data) => {
                     responseBuffer = Buffer.concat([responseBuffer, data]);
 
-                    // Check if we have received enough data
                     if (expectedLength && responseBuffer.length >= expectedLength) {
+                        // We have everything we asked for — settle now.
                         settleResolve(responseBuffer);
                     } else if (!expectedLength) {
-                        // For protocols without fixed length, wait a bit for all data
-                        clearTimeout(timeoutId);
-                        timeoutId = setTimeout(() => {
+                        // Frame length is not known up front (e.g. AA55 device
+                        // info). Reset the idle timer on each chunk; settle
+                        // when no more bytes arrive for IDLE_BYTES_TIMEOUT_MS.
+                        // The absolute deadlineTimer is intentionally NOT
+                        // touched here — it remains the upper bound.
+                        if (idleTimer) clearTimeout(idleTimer);
+                        idleTimer = setTimeout(() => {
                             settleResolve(responseBuffer);
-                        }, 100);
+                        }, IDLE_BYTES_TIMEOUT_MS);
                     }
                 };
                 socket.on("data", onData);

--- a/test/connectivity.test.js
+++ b/test/connectivity.test.js
@@ -258,6 +258,44 @@ describe("ProtocolHandler", () => {
             expect(fake.listenerCount("error")).toBe(0);
         });
 
+        it("enforces absolute deadline even when bytes trickle in (#59)", async () => {
+            // Regression: previously, every chunk reset the timeout to a 100ms
+            // idle timer, so a peer that dribbled bytes every ~90ms could hold
+            // the request open past config.timeout indefinitely.
+            const EventEmitter = require("events");
+            const handler = new ProtocolHandler({
+                protocol: "tcp",
+                // Short absolute deadline; drip bytes slower than that but
+                // faster than IDLE_BYTES_TIMEOUT_MS (100ms) to exercise the bug.
+                timeout: 250
+            });
+            const fake = new EventEmitter();
+            fake.write = () => {};
+            handler.socket = fake;
+
+            const pending = handler.sendCommand(Buffer.from([0x01])); // no expectedLength
+
+            // Drip bytes at 70ms intervals — under the 100ms idle window so
+            // the old code would never have settled via idle either. With the
+            // fix, the 250ms absolute deadline still wins.
+            const dripHandles = [];
+            for (const delay of [70, 140, 210, 280, 350, 420]) {
+                dripHandles.push(setTimeout(() => fake.emit("data", Buffer.from([0xAA])), delay));
+            }
+            // Ensure every scheduled drip is cancelled once the promise settles
+            // so it cannot leak into the next test.
+            pending.catch(() => {}).finally(() => dripHandles.forEach(clearTimeout));
+
+            const start = Date.now();
+            await expect(pending).rejects.toThrow(/timeout/i);
+            // Belt-and-suspenders: clear synchronously after the promise settles.
+            dripHandles.forEach(clearTimeout);
+
+            const elapsed = Date.now() - start;
+            expect(elapsed).toBeLessThan(1000);
+            expect(elapsed).toBeGreaterThanOrEqual(200);
+        });
+
         it("rejects fast when TCP socket emits 'close' mid-request (#58)", async () => {
             const EventEmitter = require("events");
             const handler = new ProtocolHandler({ protocol: "tcp", timeout: 5000 });


### PR DESCRIPTION
## Summary
Closes #59 (high/error-handling). When `_sendCommandImpl` was called without an `expectedLength` (every `readRuntimeData`/`readDeviceInfo` call path), each incoming chunk did `clearTimeout(timeoutId); timeoutId = setTimeout(resolve, 100)` — replacing the configured `this.config.timeout` with a 100 ms idle timer. A peer dribbling bytes every ~90 ms could hold the request alive indefinitely.

## Fix
Two independent timers:
- `deadlineTimer` (absolute): set once to `this.config.timeout`; never reset; rejects with TIMEOUT.
- `idleTimer`: only for the no-`expectedLength` branch; reset on each chunk; resolves with accumulated buffer.

Cleanup clears both. The 100 ms is extracted to a module-level `IDLE_BYTES_TIMEOUT_MS` constant with a docstring.

## Test plan
- [x] `npm test` — 290 pass (+1):
  - Drive fake TCP socket dripping bytes every 70 ms (under the 100 ms idle window) against a 250 ms absolute deadline; promise rejects with timeout in [200, 1000) ms.
- [x] `npm run lint` — clean
- [ ] CI green on 4 Node versions
- [ ] Post-merge CI green on main

## Self-review (4 perspectives)
- **Quality**: named constant; clear comments; symmetric cleanup.
- **Architecture**: pure logic fix; no API change.
- **Security**: closes a trickle-byte DoS vector for malicious or buggy TCP peers.
- **Error handling**: absolute deadline always enforced; idle timer purely optimizes frame-complete detection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)