### PR TITLE
Make worker connection fields live getters on configNode (#60)

### DIFF
--- a/nodes/info.js
+++ b/nodes/info.js
@@ -23,12 +23,15 @@ module.exports = function(RED) {
             node.status({ fill: "red", shape: "ring", text: "config error" });
             return;
         }
-
-        // Get config from configuration node
-        const cfg = configSource.getConfig();
-        node.host = cfg.host;
-        node.family = cfg.family;
         node.configNode = configSource;
+
+        // Expose connection fields as live getters so a config-node redeploy
+        // is reflected immediately instead of leaving workers with stale
+        // copies (#60).
+        Object.defineProperties(node, {
+            host:   { get: () => node.configNode.host,   configurable: true },
+            family: { get: () => node.configNode.family, configurable: true }
+        });
 
         // Register with config node for event forwarding
         node.configNode.registerUser(node);

--- a/nodes/read.js
+++ b/nodes/read.js
@@ -127,16 +127,20 @@ module.exports = function(RED) {
             node.status({ fill: "red", shape: "ring", text: "config error" });
             return;
         }
-
-        // Get config from configuration node
-        const cfg = configSource.getConfig();
-        node.host = cfg.host;
-        node.port = cfg.port;
-        node.protocol = cfg.protocol;
-        node.family = cfg.family;
-        node.timeout = cfg.timeout;
-        node.retries = cfg.retries;
         node.configNode = configSource;
+
+        // Expose connection fields as live getters that always reflect the
+        // current config-node state. Previously these were copied at
+        // construction, so a config-node redeploy left workers with stale
+        // host/port/family until they were themselves redeployed (#60).
+        Object.defineProperties(node, {
+            host:     { get: () => node.configNode.host,     configurable: true },
+            port:     { get: () => node.configNode.port,     configurable: true },
+            protocol: { get: () => node.configNode.protocol, configurable: true },
+            family:   { get: () => node.configNode.family,   configurable: true },
+            timeout:  { get: () => node.configNode.timeout,  configurable: true },
+            retries:  { get: () => node.configNode.retries,  configurable: true }
+        });
 
         // Register with config node for event forwarding
         node.configNode.registerUser(node);

--- a/test/read-node.test.js
+++ b/test/read-node.test.js
@@ -147,6 +147,32 @@ describe("GoodWe Read Node", function () {
             });
         });
 
+        it("reflects live config-node fields, not a snapshot (#60)", function (done) {
+            const flow = createReadFlow({ host: "192.168.1.100", family: "ET" });
+
+            helper.load([configNode, readNode], flow, function () {
+                const c1 = helper.getNode("c1");
+                const n1 = helper.getNode("n1");
+                try {
+                    expect(n1.host).toBe("192.168.1.100");
+                    expect(n1.family).toBe("ET");
+
+                    // Simulate a config-node field change (the v1.0 flow when
+                    // a user edits the shared config). The worker must reflect
+                    // the new value immediately, not the snapshot taken at
+                    // worker construction.
+                    c1.host = "10.0.0.42";
+                    c1.family = "DT";
+
+                    expect(n1.host).toBe("10.0.0.42");
+                    expect(n1.family).toBe("DT");
+                    done();
+                } catch (err) {
+                    done(err);
+                }
+            });
+        });
+
         it("should initialize with default output format", function (done) {
             const flow = createReadFlow({ outputFormat: undefined });
 


### PR DESCRIPTION
## Summary
Closes #60 (high/architecture). Workers cached `host`/`port`/`family`/`timeout`/`retries` at construction. A subsequent config-node field change left workers with stale snapshots — `read.js` even validated `node.host` (the snapshot) instead of the live value.

## Fix
Replace the snapshot copy with `Object.defineProperties` getters that delegate to `node.configNode` at access time. External shape unchanged (`node.host`, `node.family`, etc. still work) but every read is now live.

- `nodes/read.js`: `host`, `port`, `protocol`, `family`, `timeout`, `retries`
- `nodes/info.js`: `host`, `family`

## Follow-up flagged in commit
`config.getProtocolHandler()` still snapshots fields at first call into the `ProtocolHandler` constructor — if `configNode.host` changes AFTER the handler is built, the handler still connects to the old host. That's a lifecycle concern tracked under #71 and warrants its own PR (likely: emit a `config-changed` event from the config node and have it null out `self.protocolHandler` so the next `getProtocolHandler()` rebuilds).

## Test plan
- [x] `npm test` — 294 pass (+1):
  - Build a flow, flip `c1.host` and `c1.family` post-init, assert `n1.host` / `n1.family` show the new values.
- [x] `npm run lint` — clean
- [ ] CI green on 4 Node versions
- [ ] Post-merge CI green on main

## Self-review
- **Quality**: idiomatic `Object.defineProperties`; declarative getter list; `configurable: true` so tests can override.
- **Architecture**: worker no longer caches; configNode is the single source of truth at the worker layer.
- **Security**: no new surface.
- **Error handling**: `if (!node.host || ...)` validation now correctly reflects live state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)