### PR TITLE
Port real family/model detection from upstream goodwe (#57)

### DIFF
--- a/lib/protocol.js
+++ b/lib/protocol.js
@@ -733,63 +733,118 @@ function discoverInverters(options = {}) {
 }
 
 /**
- * Parse discovery response
- * @param {Buffer} data - Response data
+ * Inverter family classification by model-name substring (#57). Ported from
+ * upstream marcelblijleven/goodwe `goodwe/model.py` model tag tables. Tags
+ * are matched as substrings (case-insensitive) anywhere in the model name —
+ * GoodWe model strings vary in format ("GW5000-ETU", "GW10K-DT", "GW25KMT")
+ * so a strict prefix match would miss variants.
+ *
+ * Order matters where families share characters; the iteration below tries
+ * DT first (because some DT tags like "DTU" overlap with "ET..." substrings
+ * if matched loosely), then ES, then ET (which catches the platform-745
+ * hybrids).
+ */
+const FAMILY_TAGS = {
+    DT: ["DTU", "DTS", "D-NS", "DNS", "KMT", "XSU", "XS-", "MS-", "MSU"],
+    ES: ["ESU", "EMU", "BPU"],
+    ET: [
+        "ETU", "EHU", "BTU", "BHU",   // hybrid ET/EH/BT/BH
+        "ESA", "EHA",                 // ESA/EHA-G20 (platform 745 NAH)
+        "ARB", "URB", "EBR",          // platform 745
+        "NAH", "HMB", "HBB", "SPN"    // platform 745 hybrids
+    ]
+};
+
+/**
+ * Parse discovery response (AA55 device-info reply broadcast by inverters)
+ * @param {Buffer} data - Full AA55 frame as received
  * @param {string} ipAddress - IP address of the responder
- * @returns {Object|null} Parsed inverter info or null if invalid
+ * @returns {Object|null} Parsed inverter info, or null if the frame is not
+ *   a recognizable AA55 device-info reply.
  * @private
  */
 function parseDiscoveryResponse(data, ipAddress) {
     try {
-        if (data.length < 8) {
-            return null;
-        }
+        // Validate framing again at the parser boundary (the caller in
+        // discoverInverters also validates — this is defense in depth so
+        // direct callers cannot skip the check).
+        const validation = modbus.validateAA55Response(data);
+        if (!validation.valid) return null;
 
-        const inverter = {
+        const payload = modbus.extractAA55Payload(data);
+        // Need at least model name (10) + serial (16) = 26 bytes.
+        if (payload.length < 26) return null;
+
+        const modelName = payload.slice(0, 10).toString("ascii").replace(/\0/g, "").trim();
+        const serialNumber = payload.slice(10, 26).toString("ascii").replace(/\0/g, "").trim() || "UNKNOWN";
+        const family = detectInverterFamily(modelName);
+
+        return {
             ip: ipAddress,
             port: 8899,
-            family: detectInverterFamily(data),
-            serialNumber: extractSerialNumber(data),
-            modelName: extractModelName(data)
+            family,
+            serialNumber,
+            modelName
         };
-
-        return inverter;
     } catch (err) {
         return null;
     }
 }
 
 /**
- * Detect inverter family from response
- * @param {Buffer} data - Response data
- * @returns {string} Inverter family code
+ * Detect inverter family by matching the model name against the FAMILY_TAGS
+ * table. Returns null when no tag matches — the discover node falls back to
+ * a default ("ET") but null preserves the "unknown" signal in the payload.
+ *
+ * @param {string} modelName - Model name string (e.g. "GW5000-ETU")
+ * @returns {string|null} "ET" | "DT" | "ES" | null
  * @private
  */
-function detectInverterFamily(data) {
-    return "ET";
+function detectInverterFamily(modelName) {
+    if (!modelName || typeof modelName !== "string") return null;
+    const upper = modelName.toUpperCase();
+    for (const family of Object.keys(FAMILY_TAGS)) {
+        if (FAMILY_TAGS[family].some(tag => upper.includes(tag))) return family;
+    }
+    return null;
 }
 
 /**
- * Extract serial number from response
- * @param {Buffer} data - Response data
- * @returns {string} Serial number
+ * Extract the serial number from an AA55 device-info response payload.
+ * @param {Buffer} data - Full AA55 frame
+ * @returns {string} 16-byte serial number trimmed of nulls/whitespace,
+ *   or "UNKNOWN" if the frame is too short / invalid.
  * @private
  */
 function extractSerialNumber(data) {
-    if (data.length > 12) {
-        return data.slice(6, 16).toString("ascii").replace(/[^\x20-\x7E]/g, "");
+    try {
+        const validation = modbus.validateAA55Response(data);
+        if (!validation.valid) return "UNKNOWN";
+        const payload = modbus.extractAA55Payload(data);
+        if (payload.length < 26) return "UNKNOWN";
+        return payload.slice(10, 26).toString("ascii").replace(/\0/g, "").trim() || "UNKNOWN";
+    } catch (err) {
+        return "UNKNOWN";
     }
-    return "UNKNOWN";
 }
 
 /**
- * Extract model name from response
- * @param {Buffer} data - Response data
- * @returns {string} Model name
+ * Extract the model name from an AA55 device-info response payload.
+ * @param {Buffer} data - Full AA55 frame
+ * @returns {string} 10-byte model name trimmed of nulls/whitespace,
+ *   or empty string if the frame is too short / invalid.
  * @private
  */
 function extractModelName(data) {
-    return "GoodWe Inverter";
+    try {
+        const validation = modbus.validateAA55Response(data);
+        if (!validation.valid) return "";
+        const payload = modbus.extractAA55Payload(data);
+        if (payload.length < 10) return "";
+        return payload.slice(0, 10).toString("ascii").replace(/\0/g, "").trim();
+    } catch (err) {
+        return "";
+    }
 }
 
 module.exports = {
@@ -799,4 +854,8 @@ module.exports = {
     // Exported for unit tests; not part of the public Node-RED API.
     isLocalSubnet,
     ipv4ToInt,
+    detectInverterFamily,
+    extractModelName,
+    extractSerialNumber,
+    parseDiscoveryResponse,
 };

--- a/test/connectivity.test.js
+++ b/test/connectivity.test.js
@@ -590,6 +590,96 @@ describe("discovery helper functions", () => {
         }
     });
 
+    describe("family / model detection (#57)", () => {
+        const {
+            detectInverterFamily,
+            extractModelName,
+            extractSerialNumber,
+            parseDiscoveryResponse
+        } = require("../lib/protocol.js");
+        const { aa55Checksum } = require("../lib/modbus.js");
+
+        // Build an AA55 device-info frame whose payload starts with the given
+        // model and serial. Used to drive the parsers without a real inverter.
+        function buildAA55InfoFrame({ model = "GW5000-ETU", serial = "9402ETU000ABC123" } = {}) {
+            const payload = Buffer.alloc(53);
+            payload.write(model.padEnd(10, "\0").slice(0, 10), 0, "ascii");
+            payload.write(serial.padEnd(16, "\0").slice(0, 16), 10, "ascii");
+            // header: AA 55 src dst type1 type2 len
+            const header = Buffer.from([0xAA, 0x55, 0xC0, 0x7F, 0x01, 0x81, payload.length]);
+            const body = Buffer.concat([header, payload]);
+            const csum = Buffer.alloc(2);
+            csum.writeUInt16BE(aa55Checksum(body), 0);
+            return Buffer.concat([body, csum]);
+        }
+
+        it("classifies ET-family model names", () => {
+            expect(detectInverterFamily("GW5000-ETU")).toBe("ET");
+            expect(detectInverterFamily("GW10K-EHU")).toBe("ET");
+            expect(detectInverterFamily("GW3000-BTU")).toBe("ET");
+            // Platform-745 hybrids (NAH, ESA/EHA-G20)
+            expect(detectInverterFamily("GW10K-EHA-G20")).toBe("ET");
+            expect(detectInverterFamily("GW8K-NAH")).toBe("ET");
+        });
+
+        it("classifies DT-family model names (including recent KMT)", () => {
+            expect(detectInverterFamily("GW10K-DTU")).toBe("DT");
+            expect(detectInverterFamily("GW25KMT")).toBe("DT");        // 50K KMT support, upstream Mar 2026
+            expect(detectInverterFamily("GW3000-MS-30")).toBe("DT");
+        });
+
+        it("classifies ES-family model names", () => {
+            expect(detectInverterFamily("GW3000-ESU")).toBe("ES");
+            expect(detectInverterFamily("GW5000-EMU")).toBe("ES");
+        });
+
+        it("returns null for unknown/empty model strings (no false ET default)", () => {
+            expect(detectInverterFamily("Unknown")).toBeNull();
+            expect(detectInverterFamily("")).toBeNull();
+            expect(detectInverterFamily(null)).toBeNull();
+            expect(detectInverterFamily(undefined)).toBeNull();
+        });
+
+        it("is case-insensitive", () => {
+            expect(detectInverterFamily("gw5000-etu")).toBe("ET");
+            expect(detectInverterFamily("gw25kmt")).toBe("DT");
+        });
+
+        it("extractModelName / extractSerialNumber read the AA55 payload", () => {
+            const frame = buildAA55InfoFrame({ model: "GW8K-EHA", serial: "9402EHA000XYZ987" });
+            expect(extractModelName(frame)).toBe("GW8K-EHA");
+            expect(extractSerialNumber(frame)).toBe("9402EHA000XYZ987");
+        });
+
+        it("extract* return safe defaults on invalid frames", () => {
+            // Bad checksum
+            const bad = Buffer.from([0xAA, 0x55, 0xC0, 0x7F, 0x01, 0x81, 0x00, 0x00, 0x00]);
+            expect(extractModelName(bad)).toBe("");
+            expect(extractSerialNumber(bad)).toBe("UNKNOWN");
+            // Too short
+            expect(extractModelName(Buffer.from([]))).toBe("");
+            expect(extractSerialNumber(Buffer.from([]))).toBe("UNKNOWN");
+        });
+
+        it("parseDiscoveryResponse returns full inverter info from a valid frame", () => {
+            const frame = buildAA55InfoFrame({ model: "GW10K-DTU", serial: "9302DTU0001ABC22" });
+            const inv = parseDiscoveryResponse(frame, "192.168.1.50");
+            expect(inv).toEqual({
+                ip: "192.168.1.50",
+                port: 8899,
+                family: "DT",
+                modelName: "GW10K-DTU",
+                serialNumber: "9302DTU0001ABC22"
+            });
+        });
+
+        it("parseDiscoveryResponse returns null on invalid frames", () => {
+            expect(parseDiscoveryResponse(Buffer.from([]), "1.2.3.4")).toBeNull();
+            const bad = Buffer.from([0xAA, 0x55, 0xC0, 0x7F, 0x01, 0x81, 0x00, 0x00, 0x00]);
+            expect(parseDiscoveryResponse(bad, "1.2.3.4")).toBeNull();
+        });
+    });
+
     describe("source-IP filtering (#61)", () => {
         const { isLocalSubnet, ipv4ToInt } = require("../lib/protocol.js");
 


### PR DESCRIPTION
## Summary
Closes #57 (high/quality). `detectInverterFamily(data)` and `extractModelName(data)` accepted a Buffer argument in their JSDoc but ignored it — unconditionally returning `\"ET\"` and `\"GoodWe Inverter\"`. The discovery node mislabeled every responder regardless of model.

## Fix
Implement all three helpers against the AA55 device-info payload that discovery responses carry, sharing the framing implementation with the runtime read path (`validateAA55Response` + `extractAA55Payload`).

Family classification ported from upstream `marcelblijleven/goodwe` `goodwe/model.py`:
- **DT**: `DTU`, `DTS`, `D-NS`, `DNS`, `KMT` (incl. recent 50K KMT from #82), `XS*`, `MS*`
- **ES**: `ESU`, `EMU`, `BPU`
- **ET**: `ETU`, `EHU`, `BTU`, `BHU`, `ESA`, `EHA`, `ARB`, `URB`, `EBR`, `NAH`, `HMB`, `HBB`, `SPN`

Returns `null` for unknown models — the discover node still falls back to `\"ET\"` via `inv.family || \"ET\"` when consuming, preserving the resolved-shape compatibility.

## Test plan
- [x] `npm test` — 303 pass (+9)
- [x] `npm run lint` — clean (the two unused-`data` warnings that previously tracked this issue are gone)
- [ ] CI green on 4 Node versions
- [ ] Post-merge CI green on main

## Self-review
- **Quality**: declarative `FAMILY_TAGS` table; consistent JSDoc; helpers use their input now.
- **Architecture**: `FAMILY_TAGS` could fold into the single source planned by #69.
- **Security**: discovery no longer falsely labels every responder — combined with #61's source-IP filter and AA55 validation, spoofing now requires a plausible model name AND on-subnet residency AND valid AA55 framing.
- **Error handling**: invalid/short frames → safe defaults (\"\"/\"UNKNOWN\"/null), no throws.

🤖 Generated with [Claude Code](https://claude.com/claude-code)