### PR TITLE
Make Modbus TCP TX-ID per-handler with random offset (#68)

### DIFF
--- a/lib/modbus.js
+++ b/lib/modbus.js
@@ -229,16 +229,22 @@ function resetTransactionId() {
 }
 
 /**
- * Create a Modbus TCP read request
- * @param {number} commAddr - Comm address
+ * Create a Modbus TCP read request.
+ *
+ * @param {number} commAddr - Comm address (unit ID, 0-255)
  * @param {number} registerStart - Starting register address
  * @param {number} registerCount - Number of registers to read
+ * @param {number} [txId] - 16-bit transaction ID. If omitted, the legacy
+ *   module-level counter is used. ProtocolHandler passes a per-instance
+ *   counter initialised to a random offset (#68) so the next TX ID for any
+ *   one inverter session cannot be predicted from observed traffic for
+ *   another session running in the same process.
  * @returns {Buffer} 12-byte Modbus TCP request frame
  */
-function createTcpReadRequest(commAddr, registerStart, registerCount) {
-    const txId = nextTransactionId();
+function createTcpReadRequest(commAddr, registerStart, registerCount, txId) {
+    const id = (typeof txId === "number") ? (txId & 0xFFFF) : nextTransactionId();
     const frame = Buffer.alloc(12);
-    frame.writeUInt16BE(txId, 0);         // Transaction ID
+    frame.writeUInt16BE(id, 0);           // Transaction ID
     frame.writeUInt16BE(0x0000, 2);       // Protocol ID (Modbus)
     frame.writeUInt16BE(0x0006, 4);       // Length (6 bytes follow)
     frame.writeUInt8(commAddr, 6);        // Unit ID / comm address

--- a/lib/protocol.js
+++ b/lib/protocol.js
@@ -101,6 +101,12 @@ class ProtocolHandler extends EventEmitter {
         // listener still see every event — this is additive.
         this.on("error", () => {});
 
+        // Per-handler Modbus TCP transaction ID counter, initialised to a
+        // random offset (#68). A module-level monotonic counter would have
+        // made the next TX ID for any inverter session predictable from
+        // traffic observed for another session in the same process.
+        this._txId = Math.floor(Math.random() * 0xFFFF) + 1;
+
         // Resolve comm address
         this._commAddr = this.config.commAddr === "auto"
             ? modbus.getDefaultCommAddr(this.config.family)
@@ -453,6 +459,16 @@ class ProtocolHandler extends EventEmitter {
     }
 
     /**
+     * Return the next Modbus TCP transaction ID for this handler, wrapping
+     * inside the 16-bit space. See constructor comment on #68.
+     * @private
+     */
+    _nextTxId() {
+        this._txId = (this._txId % 0xFFFF) + 1;
+        return this._txId;
+    }
+
+    /**
      * Build the appropriate read command for this inverter's family/protocol
      * @returns {Buffer} Command buffer
      * @private
@@ -472,7 +488,8 @@ class ProtocolHandler extends EventEmitter {
             return modbus.createTcpReadRequest(
                 this._commAddr,
                 this._familyConfig.registerStart,
-                this._familyConfig.registerCount
+                this._familyConfig.registerCount,
+                this._nextTxId()
             );
         }
 

--- a/test/connectivity.test.js
+++ b/test/connectivity.test.js
@@ -590,6 +590,36 @@ describe("discovery helper functions", () => {
         }
     });
 
+    describe("Modbus TCP TX-ID is per-handler and unpredictable (#68)", () => {
+        it("two handlers in the same process have independent TX-ID streams", () => {
+            const h1 = new ProtocolHandler({ protocol: "tcp", family: "ET" });
+            const h2 = new ProtocolHandler({ protocol: "tcp", family: "ET" });
+
+            // Each handler initialises its TX-ID counter to a random 16-bit
+            // offset. The probability of two random 16-bit offsets colliding
+            // is 1/65535; run a handful of times to make the test stable.
+            // Instead of asserting probabilistic inequality, verify that the
+            // module-level counter is no longer the source of either stream:
+            // pull a frame from h1, then a frame from h2, and confirm h2's
+            // TX-ID is NOT (h1's + 1).
+            const f1 = h1._buildReadCommand();
+            const f2 = h2._buildReadCommand();
+            const id1 = f1.readUInt16BE(0);
+            const id2 = f2.readUInt16BE(0);
+            // h2's stream is independent of h1's, so id2 should not equal id1+1
+            // except by a 1-in-65535 coincidence we can ignore for testing.
+            expect(id2).not.toBe(((id1 % 0xFFFF) + 1));
+        });
+
+        it("TX-ID wraps within the 16-bit space", () => {
+            const h = new ProtocolHandler({ protocol: "tcp", family: "ET" });
+            // Seed near the wrap boundary
+            h._txId = 0xFFFE;
+            expect(h._nextTxId()).toBe(0xFFFF);
+            expect(h._nextTxId()).toBe(1);
+        });
+    });
+
     describe("family / model detection (#57)", () => {
         const {
             detectInverterFamily,


### PR DESCRIPTION
## Summary
Closes #68 (mid/security). `createTcpReadRequest` used a module-level `_tcpTransactionId` counter, starting at 0 and incrementing across every `ProtocolHandler` instance in the same Node-RED process. The next TX-ID was fully predictable from observed traffic for any handler.

## Threat
TX-ID isn't a security token, but it's the only correlator between Modbus TCP requests and responses on a shared socket. A LAN attacker observing one inverter session could predict TX-IDs for other inverter sessions in the same process, enabling response-injection races.

## Fix
1. `createTcpReadRequest(commAddr, registerStart, registerCount, txId?)` — `txId` is now optional. Existing callers (e.g. the modbus.test.js suite) work unchanged via the legacy module-level counter.
2. `ProtocolHandler` initialises a per-instance counter to a random 16-bit offset (`Math.floor(Math.random() * 0xFFFF) + 1`) and exposes `_nextTxId()` that wraps within the 16-bit space.
3. `_buildReadCommand` passes this value to `createTcpReadRequest`.

## Test plan
- [x] `npm test` — 305 pass (+2):
  - Two handlers in the same process have independent TX-ID streams (the second's id ≠ first's id + 1, except by 1/65535 coincidence).
  - TX-ID wraps 0xFFFE → 0xFFFF → 1.
- [x] `npm run lint` — clean
- [ ] CI green on 4 Node versions
- [ ] Post-merge CI green on main

## Self-review
- **Quality**: backward-compatible API; clear constructor comment linking to issue.
- **Architecture**: state per-instance, not module-level.
- **Security**: addresses the prediction vector directly.
- **Error handling**: n/a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)