### PR TITLE
Document inverter-data trust model (#70)

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,29 @@ See the [examples](./examples/) folder for more usage examples.
 
 The node may also work with white-label inverters using the same communication protocols.
 
+## Security & Trust Model
+
+For the full policy and how to report a vulnerability, see [SECURITY.md](./SECURITY.md).
+
+
+GoodWe inverters use AA55 (16-bit byte-sum checksum) and Modbus TCP/RTU (CRC16) framing on the local network. Both are **error-detection codes, not authentication** — anyone with the publicly documented protocol can fabricate a syntactically valid frame, and UDP source IPs are spoofable.
+
+**What this package does to mitigate spoofing:**
+- The `goodwe-discover` node, by default, rejects discovery responses whose source IP is outside the local subnet of any of the Node-RED host's network interfaces (`isLocalSubnet` filter). Opt out via `options.acceptAnySource: true` only if you knowingly need routed discovery and accept the trust boundary that creates.
+- Discovery and runtime reads validate AA55 / Modbus framing (length + checksum) before parsing, so random garbage cannot corrupt the parser. This does **not** prove the responder is the real inverter — the checksum is unkeyed.
+
+**What you must do:**
+- Do not run Node-RED on an L2 segment shared with untrusted devices when you rely on GoodWe data for automation (load-shedding, EV charging schedules, battery dispatch). A hostile device on the same network can in principle inject plausible sensor values.
+- Treat data received from the inverter as untrusted input. Validate plausibility downstream when the values drive consequential decisions (e.g. SoC must be 0–100, energy counters monotonic except after explicit reset, etc.).
+- If your inverter is on a separate VLAN or a routed segment, prefer that — and use the `acceptAnySource: true` opt-out consciously, pinning the inverter IP via DHCP reservation.
+
+**What this package does *not* protect against:**
+- A hostile device on the same L2 segment that forges AA55/Modbus frames with valid checksums.
+- TCP session hijacking by an L2 attacker.
+- DNS or ARP spoofing redirecting the configured host to an attacker.
+
+These are inherent to the protocol, not specific to this implementation.
+
 ## Development
 
 ### Prerequisites

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,44 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities by [opening a private security advisory](https://github.com/pkot/node-red-contrib-goodwe/security/advisories/new) on the repository. Do not file a public issue.
+
+Include:
+- A description of the vulnerability and its impact.
+- Steps to reproduce (or a proof of concept).
+- The package version and Node.js version you tested against.
+- Any suggested mitigation.
+
+We aim to acknowledge reports within 7 days.
+
+## Supported Versions
+
+Only the latest released minor version receives security fixes.
+
+## Trust Model
+
+This package speaks AA55 and Modbus TCP/RTU to GoodWe inverters over the local network. Both protocols use **error-detection codes (16-bit byte-sum checksum / CRC16), not authentication**. The full protocol spec is publicly documented in the upstream Python library, so anyone can fabricate syntactically valid frames.
+
+### What this package mitigates
+
+- **Discovery spoofing from outside the local subnet**: `discoverInverters` rejects responses whose source IP is outside the local subnet of any of the Node-RED host's network interfaces by default. Loopback is always trusted. Opt out with `options.acceptAnySource: true` only for routed setups, knowing you accept the trust boundary that creates.
+- **Frame-level garbage**: discovery and runtime reads validate AA55 / Modbus framing (length + magic bytes + checksum) before parsing. Malformed packets cannot corrupt parser state or trigger out-of-bounds reads.
+- **Cross-session response injection**: Modbus TCP transaction IDs are per-`ProtocolHandler` instance with a random initial offset, so the TX ID for one inverter session cannot be predicted by observing traffic for another session in the same Node-RED process.
+- **Concurrent request races**: a per-handler FIFO queue serializes `sendCommand()` so concurrent worker nodes against the same config cannot interleave responses on the shared socket.
+
+### What this package does NOT protect against
+
+- A hostile device on the same L2 segment that forges AA55 / Modbus frames with valid checksums.
+- TCP session hijacking by an L2 attacker.
+- DNS or ARP spoofing redirecting the configured host to an attacker.
+- A compromised inverter or a man-in-the-middle that the user has explicitly opted to trust via `acceptAnySource: true`.
+
+These limitations are inherent to the protocol, not specific to this implementation.
+
+### Operational guidance
+
+- Do not run Node-RED on an L2 segment shared with untrusted devices when GoodWe data drives consequential automation (load-shedding, EV charging schedules, battery dispatch).
+- If you can, put your inverter on a separate VLAN or routed segment with a DHCP reservation, and pin the configured host IP.
+- Validate sensor values downstream when they drive decisions — `battery_soc` must be 0–100, energy counters monotonic except after explicit reset, etc.
+- Keep Node-RED credentials and `flows_cred.json` private — `goodwe-config` does not store sensitive credentials today, but flow-import auditing protects you against malicious flow JSON that points at attacker-controlled hosts.


### PR DESCRIPTION
## Summary
Closes #70 (mid/security/documentation). The package now mitigates several spoofing vectors (#61 source-IP filter, #68 random TX-ID, #57 model detection) but has no end-user documentation of the trust boundary — users could build consequential automation on inverter readings without understanding what the protocol guarantees and what it doesn't.

## Changes
- New \"Security & Trust Model\" section in README.md summarising:
  - What the package mitigates (subnet filter, frame validation, random TX-ID, queue serialisation)
  - What it doesn't (same-subnet forgery with valid checksums, TCP hijacking, DNS/ARP spoofing)
  - Operational guidance (L2 segmentation, downstream plausibility checks)
- New SECURITY.md at the repo root following GitHub convention, with the same content plus private vulnerability reporting pointer.
- README cross-links SECURITY.md.

## Test plan
- [x] Docs-only changes; 305 tests still pass; lint clean
- [ ] CI green on 4 Node versions
- [ ] Post-merge CI green on main

## Self-review
- **Quality**: standard GitHub layout; consistent terminology.
- **Architecture**: makes the `acceptAnySource` opt-out's security implication explicit (was #61's hidden contract).
- **Security**: the goal — readers can now reason about what they're trusting.
- **Error handling**: n/a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)