### PR TITLE
Adopt canonical msg.timestamp / msg.inverter naming (#65)

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,8 +132,8 @@ Flat format (default):
         // ... more sensors
     },
     topic: "goodwe/runtime_data",
-    _timestamp: "2025-11-02T...",
-    _inverter: { family: "ET", host: "192.168.1.100" }
+    timestamp: "2025-11-02T...",
+    inverter: { family: "ET", host: "192.168.1.100" }
 }
 ```
 
@@ -194,8 +194,8 @@ The info node retrieves device identification and firmware information from the 
         family: "ET"
     },
     topic: "goodwe/device_info",
-    _timestamp: "2025-11-02T...",
-    _inverter: { family: "ET", host: "192.168.1.100" }
+    timestamp: "2025-11-02T...",
+    inverter: { family: "ET", host: "192.168.1.100" }
 }
 ```
 
@@ -227,7 +227,7 @@ The discover node finds GoodWe inverters on the local network using UDP broadcas
         count: 1
     },
     topic: "goodwe/discover",
-    _timestamp: "2025-11-02T..."
+    timestamp: "2025-11-02T..."
 }
 ```
 

--- a/nodes/discover.html
+++ b/nodes/discover.html
@@ -88,7 +88,7 @@
         <dt>topic <span class="property-type">string</span></dt>
         <dd>Set to "goodwe/discover"</dd>
 
-        <dt>_timestamp <span class="property-type">string</span></dt>
+        <dt>timestamp <span class="property-type">string</span></dt>
         <dd>ISO timestamp when discovery was performed</dd>
     </dl>
 
@@ -108,7 +108,7 @@
         count: 1
     },
     topic: "goodwe/discover",
-    _timestamp: "2025-11-02T..."
+    timestamp: "2025-11-02T..."
 }</pre>
 
     <h4>Output Format - No Devices Found</h4>
@@ -118,7 +118,7 @@
         count: 0
     },
     topic: "goodwe/discover",
-    _timestamp: "2025-11-02T..."
+    timestamp: "2025-11-02T..."
 }</pre>
 
     <h3>Status Updates</h3>

--- a/nodes/discover.js
+++ b/nodes/discover.js
@@ -68,8 +68,10 @@ module.exports = function(RED) {
                 // Set topic
                 outputMsg.topic = "goodwe/discover";
 
-                // Add metadata
-                outputMsg._timestamp = new Date().toISOString();
+                // Canonical worker-node metadata (#65). Discover has no
+                // single inverter to attach (the payload IS the list), so
+                // only `timestamp` is set here.
+                outputMsg.timestamp = new Date().toISOString();
 
                 // Update status based on results
                 const statusText = devices.length > 0 ? `found ${devices.length}` : "no devices";

--- a/nodes/info.html
+++ b/nodes/info.html
@@ -62,10 +62,10 @@
         <dt>topic <span class="property-type">string</span></dt>
         <dd>Set to "goodwe/device_info"</dd>
 
-        <dt>_timestamp <span class="property-type">string</span></dt>
+        <dt>timestamp <span class="property-type">string</span></dt>
         <dd>ISO timestamp when info was retrieved</dd>
 
-        <dt>_inverter <span class="property-type">object</span></dt>
+        <dt>inverter <span class="property-type">object</span></dt>
         <dd>Inverter family and host address</dd>
     </dl>
 
@@ -83,8 +83,8 @@
         family: "ET"
     },
     topic: "goodwe/device_info",
-    _timestamp: "2025-11-02T...",
-    _inverter: {
+    timestamp: "2025-11-02T...",
+    inverter: {
         family: "ET",
         host: "192.168.1.100"
     }

--- a/nodes/info.js
+++ b/nodes/info.js
@@ -76,8 +76,9 @@ module.exports = function(RED) {
                 const outputMsg = Object.assign({}, msg);
                 outputMsg.payload = deviceInfo;
                 outputMsg.topic = "goodwe/device_info";
-                outputMsg._timestamp = new Date().toISOString();
-                outputMsg._inverter = {
+                // Canonical worker-node metadata (#65).
+                outputMsg.timestamp = new Date().toISOString();
+                outputMsg.inverter = {
                     family: node.family,
                     host: node.host
                 };

--- a/nodes/read.html
+++ b/nodes/read.html
@@ -117,10 +117,10 @@
         <dt>topic <span class="property-type">string</span></dt>
         <dd>Set to "goodwe/runtime_data" if not already present in input</dd>
 
-        <dt>_timestamp <span class="property-type">string</span></dt>
+        <dt>timestamp <span class="property-type">string</span></dt>
         <dd>ISO timestamp when the data was read</dd>
 
-        <dt>_inverter <span class="property-type">object</span></dt>
+        <dt>inverter <span class="property-type">object</span></dt>
         <dd>Inverter metadata (family, host)</dd>
     </dl>
 
@@ -135,8 +135,8 @@
         // ... more sensors
     },
     topic: "goodwe/runtime_data",
-    _timestamp: "2025-11-02T...",
-    _inverter: { family: "ET", host: "192.168.1.100" }
+    timestamp: "2025-11-02T...",
+    inverter: { family: "ET", host: "192.168.1.100" }
 }</pre>
 
     <p><strong>Categorized Format:</strong></p>

--- a/nodes/read.js
+++ b/nodes/read.js
@@ -216,9 +216,10 @@ module.exports = function(RED) {
                     outputMsg.topic = "goodwe/runtime_data";
                 }
 
-                // Add metadata
-                outputMsg._timestamp = new Date().toISOString();
-                outputMsg._inverter = {
+                // Canonical worker-node metadata (#65). Standard Node-RED
+                // convention is top-level fields without underscore prefix.
+                outputMsg.timestamp = new Date().toISOString();
+                outputMsg.inverter = {
                     family: node.family,
                     host: node.host
                 };

--- a/test/discover-node.test.js
+++ b/test/discover-node.test.js
@@ -359,8 +359,8 @@ describe("goodwe-discover node", () => {
                 
                 n2.on("input", (msg) => {
                     try {
-                        expect(msg._timestamp).toBeDefined();
-                        const timestamp = new Date(msg._timestamp);
+                        expect(msg.timestamp).toBeDefined();
+                        const timestamp = new Date(msg.timestamp);
                         expect(timestamp).toBeInstanceOf(Date);
                         expect(isNaN(timestamp.getTime())).toBe(false);
                         complete();

--- a/test/info-node.test.js
+++ b/test/info-node.test.js
@@ -201,10 +201,10 @@ describe("GoodWe Info Node", function () {
 
                 n2.on("input", function (msg) {
                     try {
-                        expect(msg._timestamp).toBeDefined();
-                        expect(msg._inverter).toBeDefined();
-                        expect(msg._inverter.family).toBe("ET");
-                        expect(msg._inverter.host).toBe("192.168.1.100");
+                        expect(msg.timestamp).toBeDefined();
+                        expect(msg.inverter).toBeDefined();
+                        expect(msg.inverter.family).toBe("ET");
+                        expect(msg.inverter.host).toBe("192.168.1.100");
                         done();
                     } catch (err) {
                         done(err);

--- a/test/read-node.test.js
+++ b/test/read-node.test.js
@@ -228,10 +228,10 @@ describe("GoodWe Read Node", function () {
                 n2.on("input", function (msg) {
                     try {
                         expect(msg.topic).toBe("goodwe/runtime_data");
-                        expect(msg._timestamp).toBeDefined();
-                        expect(msg._inverter).toBeDefined();
-                        expect(msg._inverter.family).toBe("ET");
-                        expect(msg._inverter.host).toBe("192.168.1.100");
+                        expect(msg.timestamp).toBeDefined();
+                        expect(msg.inverter).toBeDefined();
+                        expect(msg.inverter.family).toBe("ET");
+                        expect(msg.inverter.host).toBe("192.168.1.100");
                         done();
                     } catch (err) {
                         done(err);


### PR DESCRIPTION
## Summary
Closes #65 (mid/architecture). Worker nodes emitted metadata under non-standard underscore-prefixed fields (`msg._timestamp`, `msg._inverter`). Node-RED convention is top-level fields without underscore prefix. Pre-1.0 is the right time to align.

## Canonical contract
| field | source | semantics |
|---|---|---|
| `msg.topic` | per-node | namespaced (`goodwe/runtime_data`, `goodwe/device_info`, `goodwe/discover`) |
| `msg.payload` | per-node | the data (sensor object / device-info / `{ devices, count }`) |
| `msg.timestamp` | all workers | ISO-8601 string |
| `msg.inverter` | read & info | `{ family, host }` (discover's payload IS the list, no single inverter) |

## Changes
- `nodes/read.js`, `nodes/info.js`, `nodes/discover.js`: emit `timestamp` / `inverter` (no underscore).
- `nodes/*.html`: editor-side help docs updated.
- `README.md`: example output blocks updated.
- Test assertions updated in `read-node.test.js`, `info-node.test.js`, `discover-node.test.js`.

## Breaking change
Yes — this changes the output `msg` shape for any user keyed on `_timestamp` / `_inverter`. The package is at 0.1.0 so this is part of v1.0 prep. Migration is one find-and-replace per affected flow.

## Test plan
- [x] `npm test` — 308 pass (no count delta; assertions updated in place)
- [x] `npm run lint` — clean
- [ ] CI green on 4 Node versions
- [ ] Post-merge CI green on main

## Self-review
- **Quality**: consistent across worker nodes + their HTML help + README.
- **Architecture**: one documented canonical shape.
- **Security**: n/a.
- **Error handling**: n/a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)