### PR TITLE
Make FAMILY_CONFIGS the single source of supported families (#69)

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -7,6 +7,8 @@
 
 "use strict";
 
+const { getSupportedFamilies } = require("./sensors");
+
 /**
  * Suggestion generators keyed by error code.
  * Each returns an array of actionable strings.
@@ -70,7 +72,9 @@ const SUGGESTION_GENERATORS = {
 
     UNSUPPORTED_FAMILY: (ctx) => [
         `Inverter family "${ctx.family || "unknown"}" is not supported`,
-        "Supported families: ET, EH, BT, BH, ES, EM, BP, DT, MS, D-NS, XS",
+        // Built at runtime from FAMILY_CONFIGS so adding a family in sensors.js
+        // automatically updates this message (#69).
+        `Supported families: ${getSupportedFamilies().join(", ")}`,
         "Check your configuration node settings"
     ],
 

--- a/lib/node-helpers.js
+++ b/lib/node-helpers.js
@@ -15,16 +15,13 @@ const { getSensors, buildSensorMetadata } = require("./sensors");
  *
  * @param {string} family - Inverter family (ET, DT, ES, etc.)
  * @returns {Object} Sensor metadata map keyed by sensor ID
+ * @throws {Error} when `family` is not in FAMILY_CONFIGS — the caller is
+ *   responsible for handling this (previously silently fell back to ET,
+ *   which masked configuration errors). See #69.
  */
 function getSensorMetadata(family) {
-    try {
-        const sensors = getSensors(family);
-        return buildSensorMetadata(sensors);
-    } catch (e) {
-        // Fall back to ET if family is unknown
-        const sensors = getSensors("ET");
-        return buildSensorMetadata(sensors);
-    }
+    const sensors = getSensors(family);
+    return buildSensorMetadata(sensors);
 }
 
 /**

--- a/lib/sensors.js
+++ b/lib/sensors.js
@@ -405,6 +405,16 @@ function getSensors(family) {
 }
 
 /**
+ * Return the list of supported inverter family codes.
+ * Single source of truth — other modules (e.g. lib/errors.js for suggestion
+ * strings) read this at runtime instead of hard-coding the list (#69).
+ * @returns {string[]} Family codes in FAMILY_CONFIGS insertion order.
+ */
+function getSupportedFamilies() {
+    return Object.keys(FAMILY_CONFIGS);
+}
+
+/**
  * Parse sensor data from a response buffer using sensor definitions.
  *
  * For Modbus families (ET, DT): byteOffset = (sensor.offset - baseRegister) * 2
@@ -490,6 +500,7 @@ module.exports = {
     typeReaders,
     getSensors,
     getFamilyConfig,
+    getSupportedFamilies,
     parseSensorData,
     buildSensorMetadata,
     ET_SENSORS,

--- a/test/sensors.test.js
+++ b/test/sensors.test.js
@@ -10,6 +10,7 @@ const {
     typeReaders,
     getSensors,
     getFamilyConfig,
+    getSupportedFamilies,
     parseSensorData,
     buildSensorMetadata,
     ET_SENSORS,
@@ -287,6 +288,34 @@ describe("getFamilyConfig", () => {
 
     test("returns null for unknown family", () => {
         expect(getFamilyConfig("XYZ")).toBeNull();
+    });
+});
+
+// ── getSupportedFamilies tests (#69) ────────────────────────────────────────
+
+describe("getSupportedFamilies (#69)", () => {
+    test("returns all keys present in FAMILY_CONFIGS", () => {
+        const families = getSupportedFamilies();
+        expect(families).toContain("ET");
+        expect(families).toContain("DT");
+        expect(families).toContain("ES");
+        expect(families).toContain("D-NS");
+        // Every returned family must be resolvable through getFamilyConfig
+        // so callers can rely on the list as a single source of truth.
+        for (const f of families) {
+            expect(getFamilyConfig(f)).not.toBeNull();
+        }
+    });
+
+    test("errors.js UNSUPPORTED_FAMILY suggestion is built from this list", () => {
+        const { SUGGESTION_GENERATORS } = require("../lib/errors");
+        const suggestions = SUGGESTION_GENERATORS.UNSUPPORTED_FAMILY({ family: "BOGUS" });
+        const families = getSupportedFamilies();
+        const supportedLine = suggestions.find(s => s.includes("Supported families"));
+        expect(supportedLine).toBeDefined();
+        for (const f of families) {
+            expect(supportedLine).toContain(f);
+        }
     });
 });
 


### PR DESCRIPTION
## Summary
Closes #69 (mid/architecture). The supported-families list was duplicated across three modules; adding a family meant hunting all three, and missing any one yielded either a misleading error message or a wrong sensor map silently.

## Changes
- `lib/sensors.js`: export `getSupportedFamilies()` returning `Object.keys(FAMILY_CONFIGS)`.
- `lib/errors.js`: `UNSUPPORTED_FAMILY` suggestion now builds the families list at runtime from `getSupportedFamilies()`.
- `lib/node-helpers.js`: remove the silent `getSensors(\"ET\")` fallback in `getSensorMetadata`. Family is already validated upstream by `ProtocolHandler._buildReadCommand` (which throws `UNSUPPORTED_FAMILY` before any read), so the fallback was dead defensive code that masked configuration bugs.

## Test plan
- [x] `npm test` — 310 pass (+2):
  - `getSupportedFamilies()` returns every key in `FAMILY_CONFIGS`, each resolvable via `getFamilyConfig`.
  - The `UNSUPPORTED_FAMILY` suggestion includes every family from `getSupportedFamilies()` (locks the contract — future drift surfaces as a test failure).
- [x] `npm run lint` — clean
- [ ] CI green on 4 Node versions
- [ ] Post-merge CI green on main

## Self-review
- **Quality**: one-line pure helper; removed dead silent-fallback path.
- **Architecture**: single source of truth — adding a family to `FAMILY_CONFIGS` propagates to user-facing error messages automatically.
- **Security**: n/a.
- **Error handling**: unknown families now surface a real error instead of being masked by silent ET fallback (already protected upstream so in practice no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)