### PR TITLE
Emit goodwe:shutdown so polling stops on config close (#71)

### DIFF
--- a/nodes/config.js
+++ b/nodes/config.js
@@ -95,12 +95,36 @@ module.exports = function(RED) {
         };
 
         /**
-         * Cleanup on node close
+         * Cleanup on node close.
+         *
+         * Sequence (#71):
+         * 1. Emit `goodwe:shutdown` to every registered worker so they can
+         *    cancel polling intervals before we tear down the handler. Doing
+         *    this first prevents a ghost tick from racing with disconnect()
+         *    and re-creating a handler post-close.
+         * 2. Disconnect the ProtocolHandler with a 2000ms safety timeout.
+         *    Node 24+'s dgram.close() can throw "Not running" on unbound
+         *    sockets (already handled in lib/protocol.js for discovery); for
+         *    a wedged TCP socket the underlying socket.end() callback may
+         *    never fire, which previously hung Node-RED's deploy.
          */
         this.on("close", async function(done) {
-            // Disconnect the protocol handler
+            // Signal users first so polling stops before we destroy the handler.
+            for (const node of self.users) {
+                try { node.emit("goodwe:shutdown"); } catch (_e) { /* ignore */ }
+            }
+
             if (self.protocolHandler) {
-                await self.protocolHandler.disconnect();
+                const DISCONNECT_TIMEOUT_MS = 2000;
+                try {
+                    await Promise.race([
+                        self.protocolHandler.disconnect(),
+                        new Promise(resolve => setTimeout(resolve, DISCONNECT_TIMEOUT_MS))
+                    ]);
+                } catch (_e) {
+                    // Swallow — close path must always call done() so the
+                    // Node-RED deploy completes.
+                }
                 self.protocolHandler = null;
             }
             self.users = [];

--- a/nodes/read.js
+++ b/nodes/read.js
@@ -168,6 +168,18 @@ module.exports = function(RED) {
             node.warn(`Protocol error: ${err.message}`);
         });
 
+        // Stop polling immediately when the config node signals shutdown so
+        // we don't race with its protocolHandler teardown (#71). Without
+        // this, a polling tick can re-lazy-create a fresh handler against
+        // stale state during the deploy window.
+        node.on("goodwe:shutdown", function() {
+            if (node.pollingInterval) {
+                clearInterval(node.pollingInterval);
+                node.pollingInterval = null;
+            }
+            node.status({ fill: "grey", shape: "ring", text: "config closing" });
+        });
+
         /**
          * Perform read operation
          * @param {Object} msg - Input message

--- a/test/read-node.test.js
+++ b/test/read-node.test.js
@@ -631,6 +631,53 @@ describe("GoodWe Read Node", function () {
         });
     });
 
+    describe("Polling lifecycle vs config-node close (#71)", function () {
+
+        it("clears polling interval when config node emits goodwe:shutdown", function (done) {
+            const flow = createReadFlow({ polling: 1 });
+
+            helper.load([configNode, readNode], flow, function () {
+                const n1 = helper.getNode("n1");
+                expect(n1.pollingInterval).toBeDefined();
+
+                // Simulate the config-node close handler firing the shutdown
+                // event. The read node should stop polling and null the
+                // interval handle.
+                n1.emit("goodwe:shutdown");
+
+                setImmediate(() => {
+                    try {
+                        expect(n1.pollingInterval).toBeNull();
+                        done();
+                    } catch (err) {
+                        done(err);
+                    }
+                });
+            });
+        });
+
+        it("config-node close (helper.unload) emits goodwe:shutdown to users", function (done) {
+            const flow = createReadFlow();
+            helper.load([configNode, readNode], flow, function () {
+                const n1 = helper.getNode("n1");
+
+                let shutdownSeen = false;
+                n1.on("goodwe:shutdown", () => { shutdownSeen = true; });
+
+                // Driver Node-RED's normal close path. Unload triggers each
+                // node's "close" handler in dependency order.
+                helper.unload().then(() => {
+                    try {
+                        expect(shutdownSeen).toBe(true);
+                        done();
+                    } catch (err) {
+                        done(err);
+                    }
+                });
+            });
+        });
+    });
+
     describe("Error Handling", function () {
 
         it("should handle read errors gracefully", function (done) {


### PR DESCRIPTION
## Summary
Closes #71 (mid/architecture/error-handling). Two lifecycle gaps closed:

1. A `goodwe-read` polling timer kept firing during config-node redeploy and re-lazy-created a fresh `ProtocolHandler` after the config node's close handler nulled the old one — a ghost handler/socket during the deploy window.
2. The config close handler awaited `disconnect()` with no upper bound. A wedged TCP socket whose `end()` callback never fired hung the Node-RED deploy indefinitely.

## Fix
- `nodes/config.js` close: emit `goodwe:shutdown` to every registered worker FIRST (before tearing down the handler), then wrap `disconnect()` in `Promise.race` against a `DISCONNECT_TIMEOUT_MS = 2000` deadline and swallow any throw — the close path must always call `done()`.
- `nodes/read.js`: register a `goodwe:shutdown` listener that clears `pollingInterval` and sets a \"config closing\" status.

## Test plan
- [x] `npm test` — 312 pass (+2):
  - Read node clears `pollingInterval` upon `goodwe:shutdown`.
  - Config-node close via `helper.unload()` emits `goodwe:shutdown` to registered users.
- [x] `npm run lint` — clean
- [ ] CI green on 4 Node versions
- [ ] Post-merge CI green on main

## Self-review
- **Quality**: named timeout constant; explicit listener wiring.
- **Architecture**: explicit shutdown signal; eliminates ghost-tick race during deploy.
- **Security**: n/a.
- **Error handling**: deploy can no longer hang on a wedged socket; try/catch in close path guarantees `done()` is called.

🤖 Generated with [Claude Code](https://claude.com/claude-code)