### PR TITLE
Bounds-check extract* helpers internally (#73)

### DIFF
--- a/lib/modbus.js
+++ b/lib/modbus.js
@@ -197,14 +197,25 @@ function validateRtuResponse(data, expectedCmd, expectedCount) {
 /**
  * Extract payload from Modbus RTU response (strip 5-byte header + 2-byte CRC)
  * Header: AA(1) 55(1) addr(1) cmd(1) bytecount(1)
+ *
+ * Self-contained bounds check (#73): the byteCount byte is attacker-
+ * controlled (a hostile or buggy peer can set it to anything 0-255). If the
+ * caller didn't validate, Buffer.slice would silently return a shorter
+ * buffer than the byteCount claims — a subsequent readUInt32BE near the
+ * end would silently return wrong data.
+ *
  * @param {Buffer} data - RTU response
  * @returns {Buffer} Payload data
+ * @throws {Error} when the buffer is too short to contain `5 + byteCount + 2`.
  */
 function extractRtuPayload(data) {
     if (data.length < 7) {
         throw new Error("RTU response too short to extract payload");
     }
     const byteCount = data[4];
+    if (data.length < 5 + byteCount + 2) {
+        throw new Error(`RTU frame truncated: declared ${byteCount} bytes, have ${data.length - 7}`);
+    }
     return data.slice(5, 5 + byteCount);
 }
 
@@ -294,14 +305,21 @@ function validateTcpResponse(data, expectedCmd, expectedCount) {
 /**
  * Extract payload from Modbus TCP response (strip 9-byte header)
  * Header: txId(2) + protocolId(2) + length(2) + unitId(1) + cmd(1) + bytecount(1)
+ *
+ * Self-contained bounds check (#73): see extractRtuPayload — same hazard.
+ *
  * @param {Buffer} data - TCP response
  * @returns {Buffer} Payload data
+ * @throws {Error} when the buffer is too short to contain `9 + byteCount`.
  */
 function extractTcpPayload(data) {
     if (data.length < 9) {
         throw new Error("TCP response too short to extract payload");
     }
     const byteCount = data[8];
+    if (data.length < 9 + byteCount) {
+        throw new Error(`TCP frame truncated: declared ${byteCount} bytes, have ${data.length - 9}`);
+    }
     return data.slice(9, 9 + byteCount);
 }
 

--- a/test/modbus.test.js
+++ b/test/modbus.test.js
@@ -280,6 +280,12 @@ describe("Modbus RTU", () => {
         test("throws for too-short response", () => {
             expect(() => extractRtuPayload(Buffer.from([0xAA]))).toThrow();
         });
+
+        test("throws when declared byteCount exceeds buffer (#73)", () => {
+            // Header claims 100-byte payload but only 2 bytes follow.
+            const truncated = Buffer.from([0xAA, 0x55, 0xF7, 0x03, 100, 0x11, 0x22]);
+            expect(() => extractRtuPayload(truncated)).toThrow(/truncated/i);
+        });
     });
 });
 
@@ -391,6 +397,12 @@ describe("Modbus TCP", () => {
 
         test("throws for too-short response", () => {
             expect(() => extractTcpPayload(Buffer.alloc(5))).toThrow();
+        });
+
+        test("throws when declared byteCount exceeds buffer (#73)", () => {
+            // 9-byte header with byteCount=200 but only 2 bytes of payload.
+            const truncated = Buffer.from([0x00, 0x01, 0x00, 0x00, 0x00, 0xCB, 0xF7, 0x03, 200, 0x11, 0x22]);
+            expect(() => extractTcpPayload(truncated)).toThrow(/truncated/i);
         });
     });
 });


### PR DESCRIPTION
## Summary
Closes #73 (low/security). `extractRtuPayload` / `extractTcpPayload` sliced using an attacker-controlled byte-count from the response with no internal length check. Safe today because every caller validates first — exporting the functions means a future caller could skip validation and silently get a truncated buffer.

## Fix
- RTU: throw when `data.length < 5 + byteCount + 2`
- TCP: throw when `data.length < 9 + byteCount`

Error messages include the declared vs actual byte counts.

## Test plan
- [x] `npm test` — 314 pass (+2)
- [x] `npm run lint` — clean
- [ ] CI green on 4 Node versions
- [ ] Post-merge CI green on main

## Self-review
- **Quality**: minor change; clear errors when triggered.
- **Architecture**: helpers now self-contained.
- **Security**: closes a latent OOB scenario for direct callers.
- **Error handling**: declared/actual byte counts in the message aid debugging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)