### PR TITLE
Validate commAddr to a Modbus unit-ID byte (#74)

### DIFF
--- a/lib/protocol.js
+++ b/lib/protocol.js
@@ -68,6 +68,31 @@ function isLocalSubnet(ipAddress) {
 }
 
 /**
+ * Resolve a user-supplied `commAddr` config value to a Modbus unit ID byte.
+ * See ProtocolHandler constructor for the policy.
+ * @param {string|number|null|undefined} value
+ * @param {string} family
+ * @returns {number} unit ID in [0, 255]
+ * @throws {Error} INVALID_CONFIG when `value` is provided but cannot be
+ *   parsed as a byte.
+ */
+function resolveCommAddr(value, family) {
+    if (value === undefined || value === null || value === "" || value === "auto") {
+        return modbus.getDefaultCommAddr(family);
+    }
+    const parsed = (typeof value === "number") ? value : parseInt(value, 16);
+    if (!Number.isInteger(parsed) || parsed < 0 || parsed > 0xFF) {
+        const err = new Error(
+            `Invalid commAddr ${JSON.stringify(value)}: ` +
+            "must be a hex byte 0x00-0xFF or \"auto\""
+        );
+        err.code = "INVALID_CONFIG";
+        throw err;
+    }
+    return parsed;
+}
+
+/**
  * Protocol Handler for GoodWe Inverters
  */
 class ProtocolHandler extends EventEmitter {
@@ -107,10 +132,14 @@ class ProtocolHandler extends EventEmitter {
         // traffic observed for another session in the same process.
         this._txId = Math.floor(Math.random() * 0xFFFF) + 1;
 
-        // Resolve comm address
-        this._commAddr = this.config.commAddr === "auto"
-            ? modbus.getDefaultCommAddr(this.config.family)
-            : parseInt(this.config.commAddr, 16) || modbus.getDefaultCommAddr(this.config.family);
+        // Resolve comm address.
+        // Modbus unit IDs live in 1 byte (0-255). A malformed `commAddr` from
+        // a flow import (e.g. "0x1FF" → 511) would crash the first write with
+        // a RangeError deep inside Buffer.writeUInt8 (#74). Validate up-front:
+        //   - "auto", "", null, undefined → family default
+        //   - parseable hex byte in [0, 255] → use it
+        //   - anything else (out of range, non-numeric) → throw INVALID_CONFIG
+        this._commAddr = resolveCommAddr(this.config.commAddr, this.config.family);
 
         // Get family configuration for sensor definitions
         this._familyConfig = getFamilyConfig(this.config.family);

--- a/test/connectivity.test.js
+++ b/test/connectivity.test.js
@@ -590,6 +590,40 @@ describe("discovery helper functions", () => {
         }
     });
 
+    describe("commAddr validation (#74)", () => {
+        it("accepts auto / empty / undefined and uses family default", () => {
+            expect(() => new ProtocolHandler({ commAddr: "auto", family: "ET" })).not.toThrow();
+            expect(() => new ProtocolHandler({ commAddr: "", family: "ET" })).not.toThrow();
+            expect(() => new ProtocolHandler({ family: "ET" })).not.toThrow();
+        });
+
+        it("accepts in-range hex string / number", () => {
+            expect(() => new ProtocolHandler({ commAddr: "F7", family: "ET" })).not.toThrow();
+            expect(() => new ProtocolHandler({ commAddr: 0x7F, family: "DT" })).not.toThrow();
+            expect(() => new ProtocolHandler({ commAddr: "00", family: "ET" })).not.toThrow();
+            expect(() => new ProtocolHandler({ commAddr: "FF", family: "ET" })).not.toThrow();
+        });
+
+        it("rejects out-of-range values with INVALID_CONFIG", () => {
+            try {
+                new ProtocolHandler({ commAddr: "1FF", family: "ET" }); // 511
+                throw new Error("expected throw");
+            } catch (err) {
+                expect(err.code).toBe("INVALID_CONFIG");
+                expect(err.message).toContain("0x00-0xFF");
+            }
+        });
+
+        it("rejects unparseable values with INVALID_CONFIG", () => {
+            try {
+                new ProtocolHandler({ commAddr: "garbage", family: "ET" });
+                throw new Error("expected throw");
+            } catch (err) {
+                expect(err.code).toBe("INVALID_CONFIG");
+            }
+        });
+    });
+
     describe("protocol-validation errors carry PROTOCOL_ERROR code (#67)", () => {
         it("malformed AA55 frame surfaces as PROTOCOL_ERROR, not READ_ERROR", () => {
             const handler = new ProtocolHandler({ protocol: "udp", family: "ES" });


### PR DESCRIPTION
## Summary
Closes #74 (low/security). `ProtocolHandler` accepted any `commAddr` and stored it after `parseInt(value, 16) || default`. A malformed value from a flow import (e.g. `\"0x1FF\"` → 511) would crash the first write with `RangeError` deep in `Buffer.writeUInt8`.

## Fix
New `resolveCommAddr(value, family)` module helper with policy:
- `\"auto\"` / `\"\"` / `null` / `undefined` → family default
- in-range hex string or number → use it
- anything else → throw `INVALID_CONFIG` with a clear message

## Test plan
- [x] `npm test` — 318 pass (+4)
- [x] `npm run lint` — clean
- [ ] CI green on 4 Node versions
- [ ] Post-merge CI green on main

## Self-review
- **Quality**: extracted helper; clear error containing the offending value and valid range.
- **Architecture**: validation up-front beats failing deep in Buffer code.
- **Security**: rejects out-of-range input from flow imports (a low-effort flow change that previously crashed reads).
- **Error handling**: surfaces as `INVALID_CONFIG` (a new code; `enhanceError`'s `getDefaultSuggestions` handles unknown codes gracefully).

🤖 Generated with [Claude Code](https://claude.com/claude-code)