### PR TITLE
Use Number() + isInteger() + range checks for user numeric inputs (#75)

### DIFF
--- a/lib/node-helpers.js
+++ b/lib/node-helpers.js
@@ -64,6 +64,32 @@ function setTransientStatus(node, opts = {}) {
  * @param {Object} ev - ProtocolHandler status event
  * @returns {Object} Node-RED status object
  */
+/**
+ * Parse a user-supplied numeric config value defensively. parseInt without
+ * a radix accepts surprising input — `parseInt("1e6")` returns 1, not 1e6 —
+ * so a polling/timeout typed in scientific notation could silently become
+ * a 1ms value and flood the network (#75).
+ *
+ * Returns the default for empty / null / undefined / unparseable input and
+ * for values outside [min, max]. Otherwise returns the integer.
+ *
+ * @param {*} value
+ * @param {Object} opts
+ * @param {number} opts.default - Returned when input is missing/invalid.
+ * @param {number} [opts.min]   - Inclusive lower bound. Default 0.
+ * @param {number} [opts.max]   - Inclusive upper bound. Default Number.MAX_SAFE_INTEGER.
+ * @returns {number}
+ */
+function parseSafeInteger(value, opts) {
+    const def = opts.default;
+    const min = typeof opts.min === "number" ? opts.min : 0;
+    const max = typeof opts.max === "number" ? opts.max : Number.MAX_SAFE_INTEGER;
+    if (value === undefined || value === null || value === "") return def;
+    const n = Number(value);
+    if (!Number.isInteger(n) || n < min || n > max) return def;
+    return n;
+}
+
 function mapProtocolStatus(ev) {
     switch (ev.state) {
     case "connecting":   return STATUSES.connecting;
@@ -106,5 +132,6 @@ module.exports = {
     STATUS_RESET_MS,
     STATUSES,
     setTransientStatus,
-    mapProtocolStatus
+    mapProtocolStatus,
+    parseSafeInteger
 };

--- a/nodes/discover.js
+++ b/nodes/discover.js
@@ -6,7 +6,7 @@
  */
 
 const protocol = require("../lib/protocol.js");
-const { STATUSES, setTransientStatus } = require("../lib/node-helpers.js");
+const { STATUSES, setTransientStatus, parseSafeInteger } = require("../lib/node-helpers.js");
 
 // Constants
 const DEFAULT_PORT = 8899;
@@ -23,7 +23,10 @@ module.exports = function(RED) {
         const node = this;
 
         // Node properties
-        node.timeout = parseInt(config.timeout) || 5000;
+        // Defensive parse (#75) — guard against scientific notation, negative
+        // values, etc. typed via flow import. Floor 100ms (sub-100ms is
+        // unrealistic for UDP round-trip), ceiling 5 min.
+        node.timeout = parseSafeInteger(config.timeout, { default: 5000, min: 100, max: 300000 });
         node.broadcastAddress = config.broadcastAddress || "255.255.255.255";
         
         // Track pending timers for cleanup

--- a/nodes/read.js
+++ b/nodes/read.js
@@ -9,7 +9,8 @@ const {
     getSensorMetadata,
     STATUSES,
     setTransientStatus,
-    mapProtocolStatus
+    mapProtocolStatus,
+    parseSafeInteger
 } = require("../lib/node-helpers.js");
 const { enhanceError } = require("../lib/errors.js");
 
@@ -153,7 +154,10 @@ module.exports = function(RED) {
 
         // Node properties
         node.outputFormat = config.outputFormat || "flat";
-        node.polling = parseInt(config.polling) || 0;
+        // Defensive parse (#75). Polling cadence is in seconds; 0 = disabled.
+        // Sanity cap at 86400s (1 day) — beyond that the value almost
+        // certainly came from a malformed flow import.
+        node.polling = parseSafeInteger(config.polling, { default: 0, min: 0, max: 86400 });
 
         // Polling interval ID
         node.pollingInterval = null;

--- a/test/node-helpers.test.js
+++ b/test/node-helpers.test.js
@@ -1,0 +1,86 @@
+/**
+ * Tests for lib/node-helpers.js helpers.
+ */
+
+const {
+    parseSafeInteger,
+    STATUSES,
+    setTransientStatus,
+    mapProtocolStatus,
+    STATUS_RESET_MS
+} = require("../lib/node-helpers");
+
+describe("parseSafeInteger (#75)", () => {
+    test("returns default for empty / null / undefined input", () => {
+        expect(parseSafeInteger("", { default: 42 })).toBe(42);
+        expect(parseSafeInteger(null, { default: 42 })).toBe(42);
+        expect(parseSafeInteger(undefined, { default: 42 })).toBe(42);
+    });
+
+    test("returns integer when input is in range", () => {
+        expect(parseSafeInteger("100", { default: 0 })).toBe(100);
+        expect(parseSafeInteger(250, { default: 0 })).toBe(250);
+        expect(parseSafeInteger("0", { default: 99 })).toBe(0); // 0 is valid, not coerced to default
+    });
+
+    test("returns default when below min or above max", () => {
+        expect(parseSafeInteger(50, { default: 5000, min: 100 })).toBe(5000);
+        expect(parseSafeInteger(1e7, { default: 5000, max: 1000 })).toBe(5000);
+    });
+
+    test("returns default for non-integer / NaN input", () => {
+        expect(parseSafeInteger("abc", { default: 5000 })).toBe(5000);
+        expect(parseSafeInteger("1.5", { default: 5000 })).toBe(5000);
+        expect(parseSafeInteger(NaN, { default: 5000 })).toBe(5000);
+        expect(parseSafeInteger(Infinity, { default: 5000 })).toBe(5000);
+    });
+
+    test("Number() correctly parses scientific notation (vs parseInt)", () => {
+        // The bug parseInt(\"1e6\") returns 1, silently flooding the network.
+        // Number(\"1e6\") returns 1_000_000 — accept it (within cap).
+        expect(parseSafeInteger("1e6", { default: 5000, max: 2_000_000 })).toBe(1_000_000);
+    });
+});
+
+describe("STATUSES and setTransientStatus (#66)", () => {
+    test("STATUSES is frozen with canonical bundles", () => {
+        expect(Object.isFrozen(STATUSES)).toBe(true);
+        expect(STATUSES.ready).toEqual({ fill: "grey", shape: "ring", text: "ready" });
+        expect(STATUSES.ok).toEqual({ fill: "green", shape: "dot", text: "ok" });
+        expect(STATUSES.error).toEqual({ fill: "red", shape: "ring", text: "error" });
+    });
+
+    test("STATUS_RESET_MS is exported", () => {
+        expect(STATUS_RESET_MS).toBe(2000);
+    });
+
+    test("setTransientStatus applies status now, schedules reset, unrefs timer", () => {
+        jest.useFakeTimers();
+        const calls = [];
+        const node = { status: (s) => calls.push(s) };
+        setTransientStatus(node);
+        expect(calls[0]).toEqual(STATUSES.ok);
+        jest.advanceTimersByTime(STATUS_RESET_MS);
+        expect(calls[1]).toEqual(STATUSES.ready);
+        jest.useRealTimers();
+    });
+});
+
+describe("mapProtocolStatus (#66)", () => {
+    test("translates known states", () => {
+        expect(mapProtocolStatus({ state: "connecting" })).toEqual(STATUSES.connecting);
+        expect(mapProtocolStatus({ state: "connected" })).toEqual(STATUSES.connected);
+        expect(mapProtocolStatus({ state: "reading" })).toEqual(STATUSES.reading);
+    });
+
+    test("retrying includes attempt/maxRetries when present", () => {
+        const r = mapProtocolStatus({ state: "retrying", attempt: 2, maxRetries: 3 });
+        expect(r.fill).toBe("orange");
+        expect(r.text).toBe("retry 2/3");
+    });
+
+    test("unknown state falls back to grey with the raw label", () => {
+        const r = mapProtocolStatus({ state: "exploded" });
+        expect(r).toEqual({ fill: "grey", shape: "ring", text: "exploded" });
+    });
+});


### PR DESCRIPTION
## Summary
Closes #75 (low/security). `parseInt()` without a radix accepted surprising input — `parseInt(\"1e6\")` returns `1`, so polling cadence typed in scientific notation could silently become 1-second polling (or 1ms timeout) and flood the network.

## Fix
New `parseSafeInteger(value, { default, min, max })` helper in `lib/node-helpers.js` using `Number()` + `Number.isInteger()` + explicit bounds. Each caller specifies a sane range:
- `discover.timeout`: `[100, 300000]` ms (UDP RTT floor, 5 min ceiling)
- `read.polling`: `[0, 86400]` seconds (0 = disabled; 1 day ceiling catches malformed flow imports)

Also adds a new `test/node-helpers.test.js` covering both this PR's helper and the `#66` helpers that previously had no direct tests.

## Test plan
- [x] `npm test` — 329 pass (+11)
- [x] `npm run lint` — clean
- [ ] CI green on 4 Node versions
- [ ] Post-merge CI green on main

## Self-review
- **Quality**: shared helper; backfill tests for previously-untested node-helpers exports.
- **Architecture**: validation moves to the helper module; nodes stay thin.
- **Security**: closes scientific-notation flooding vector.
- **Error handling**: graceful default-fallback; no throws (matches existing UX).

🤖 Generated with [Claude Code](https://claude.com/claude-code)