### PR TITLE
Reject public broadcast addresses for discovery probe (#76)

### DIFF
--- a/lib/protocol.js
+++ b/lib/protocol.js
@@ -68,6 +68,34 @@ function isLocalSubnet(ipAddress) {
 }
 
 /**
+ * Return true for IPv4 broadcast/multicast/unicast addresses that are safe
+ * to use as a discovery broadcast target without leaking the AA55 probe over
+ * routed links to public hosts (#76):
+ *   - 255.255.255.255 (limited broadcast — never leaves the local segment)
+ *   - RFC1918 private ranges: 10/8, 172.16/12, 192.168/16
+ *   - 169.254/16 link-local
+ *   - 224/4 link-local multicast (224.0.0.0/24 specifically)
+ * Any other address is treated as public and rejected.
+ *
+ * Returns false on parse errors so callers fail closed.
+ * @param {string} ipAddress
+ * @returns {boolean}
+ */
+function isPrivateBroadcast(ipAddress) {
+    const addr = ipv4ToInt(ipAddress);
+    if (addr === null) return false;
+    if (addr === 0xFFFFFFFF) return true; // 255.255.255.255 limited broadcast
+    const top = (addr & 0xFF000000) >>> 24;
+    const second = (addr & 0x00FF0000) >>> 16;
+    if (top === 10) return true;                                // 10.0.0.0/8
+    if (top === 172 && second >= 16 && second <= 31) return true; // 172.16.0.0/12
+    if (top === 192 && second === 168) return true;             // 192.168.0.0/16
+    if (top === 169 && second === 254) return true;             // 169.254.0.0/16 link-local
+    if (top === 224 && second === 0) return true;               // 224.0.0.0/24 link-local multicast
+    return false;
+}
+
+/**
  * Resolve a user-supplied `commAddr` config value to a Modbus unit ID byte.
  * See ProtocolHandler constructor for the policy.
  * @param {string|number|null|undefined} value
@@ -699,7 +727,13 @@ function parseDeviceInfo(payload) {
  * Discover GoodWe inverters on the network
  * @param {Object} options - Discovery options
  * @param {number} options.timeout - Discovery timeout in ms (default: 5000)
- * @param {string} options.broadcastAddress - Broadcast address (default: 255.255.255.255)
+ * @param {string} options.broadcastAddress - Broadcast address (default:
+ *   255.255.255.255). Rejected if it isn't an RFC1918/link-local/limited-
+ *   broadcast address — see `isPrivateBroadcast`. Override the rejection by
+ *   setting `options.allowPublicBroadcast: true` (you are then responsible
+ *   for ensuring the AA55 probe does not leak over routed links).
+ * @param {boolean} options.allowPublicBroadcast - Opt-out of the
+ *   broadcastAddress private-range check (#76). Default false.
  * @param {boolean} options.acceptAnySource - When true, skip the local-subnet
  *   source-IP filter and accept discovery responses from any host. Default
  *   false. Only enable for routed setups where the inverter is reachable but
@@ -712,6 +746,25 @@ function discoverInverters(options = {}) {
         const timeout = options.timeout || 5000;
         const broadcastAddress = options.broadcastAddress || "255.255.255.255";
         const acceptAnySource = options.acceptAnySource === true;
+        const allowPublicBroadcast = options.allowPublicBroadcast === true;
+
+        // Refuse to broadcast to public IPs unless the caller explicitly
+        // opted out (#76). The AA55 discovery probe contains nothing
+        // sensitive itself, but blasting it over routed links to the
+        // internet at large is a hygiene issue and can trigger firewall
+        // alerts for whoever owns the destination.
+        if (!allowPublicBroadcast && !isPrivateBroadcast(broadcastAddress)) {
+            const err = new Error(
+                "Refusing to broadcast discovery probe to non-private address " +
+                `${JSON.stringify(broadcastAddress)}. ` +
+                "Use a private (RFC1918), link-local, or limited-broadcast address, " +
+                "or set options.allowPublicBroadcast=true to override."
+            );
+            err.code = "INVALID_CONFIG";
+            reject(err);
+            return;
+        }
+
         const discoveredInverters = [];
         const socket = dgram.createSocket("udp4");
 
@@ -909,6 +962,7 @@ module.exports = {
     parseDeviceInfo,
     // Exported for unit tests; not part of the public Node-RED API.
     isLocalSubnet,
+    isPrivateBroadcast,
     ipv4ToInt,
     detectInverterFamily,
     extractModelName,

--- a/test/connectivity.test.js
+++ b/test/connectivity.test.js
@@ -771,6 +771,61 @@ describe("discovery helper functions", () => {
         });
     });
 
+    describe("broadcast address validation (#76)", () => {
+        const { isPrivateBroadcast, discoverInverters } = require("../lib/protocol.js");
+
+        it("accepts limited broadcast and RFC1918 ranges", () => {
+            expect(isPrivateBroadcast("255.255.255.255")).toBe(true);
+            expect(isPrivateBroadcast("192.168.1.255")).toBe(true);
+            expect(isPrivateBroadcast("10.0.0.255")).toBe(true);
+            expect(isPrivateBroadcast("172.16.0.255")).toBe(true);
+            expect(isPrivateBroadcast("172.31.255.255")).toBe(true);
+            expect(isPrivateBroadcast("169.254.0.1")).toBe(true); // link-local
+            expect(isPrivateBroadcast("224.0.0.1")).toBe(true);   // link-local mcast
+        });
+
+        it("rejects public IPs", () => {
+            expect(isPrivateBroadcast("8.8.8.8")).toBe(false);
+            expect(isPrivateBroadcast("1.1.1.1")).toBe(false);
+            expect(isPrivateBroadcast("172.32.0.1")).toBe(false); // outside 172.16/12
+            expect(isPrivateBroadcast("172.15.255.255")).toBe(false);
+        });
+
+        it("rejects malformed input (fail-closed)", () => {
+            expect(isPrivateBroadcast("")).toBe(false);
+            expect(isPrivateBroadcast(null)).toBe(false);
+            expect(isPrivateBroadcast("not.an.address")).toBe(false);
+        });
+
+        it("discoverInverters refuses a public broadcast address without opt-out", async () => {
+            await expect(
+                discoverInverters({ timeout: 100, broadcastAddress: "8.8.8.8" })
+            ).rejects.toMatchObject({
+                code: "INVALID_CONFIG",
+                message: expect.stringContaining("non-private")
+            });
+        });
+
+        it("discoverInverters accepts public broadcast with allowPublicBroadcast=true", async () => {
+            // Doesn't reject for the broadcastAddress reason. The actual
+            // socket.send may fail downstream depending on the environment;
+            // we just verify the up-front policy check is bypassed.
+            let caught;
+            try {
+                await discoverInverters({
+                    timeout: 100,
+                    broadcastAddress: "8.8.8.8",
+                    allowPublicBroadcast: true
+                });
+            } catch (e) {
+                caught = e;
+            }
+            if (caught) {
+                expect(caught.code).not.toBe("INVALID_CONFIG");
+            }
+        });
+    });
+
     describe("source-IP filtering (#61)", () => {
         const { isLocalSubnet, ipv4ToInt } = require("../lib/protocol.js");
 


### PR DESCRIPTION
## Summary
Closes #76 (low/security). `discoverInverters` passed `broadcastAddress` to `socket.send` with no validation. A flow import (or msg.payload) could set it to a public IP and blast the AA55 probe over routed links to the internet at large.

## Fix
New `isPrivateBroadcast(ip)` helper accepts only:
- `255.255.255.255` (limited broadcast)
- RFC1918 (`10/8`, `172.16/12`, `192.168/16`)
- `169.254/16` link-local
- `224.0.0.0/24` link-local multicast

`discoverInverters` rejects non-private addresses with `INVALID_CONFIG` before touching the socket. `options.allowPublicBroadcast: true` opt-out for callers who knowingly need it — same pattern as #61's `acceptAnySource`.

Note: the UDP socket still binds to `0.0.0.0`. With #61's source-IP filter, responses from non-local subnets are already dropped. Tightening the bind to a specific interface is a bigger lifecycle change and would constrain multi-homed setups; left as a future hardening if needed.

## Test plan
- [x] `npm test` — 334 pass (+5)
- [x] `npm run lint` — clean
- [ ] CI green on 4 Node versions
- [ ] Post-merge CI green on main

## Self-review
- **Quality**: pure helper; tested boundaries on 172.16/12.
- **Architecture**: opt-out pattern matches #61's `acceptAnySource` — consistent.
- **Security**: closes the leak-AA55-to-public-IP hygiene issue.
- **Error handling**: `INVALID_CONFIG` code with actionable message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)