### PR TITLE
Polling failures fire Catch nodes; isReading guards input too (#77)

### DIFF
--- a/nodes/read.js
+++ b/nodes/read.js
@@ -276,7 +276,20 @@ module.exports = function(RED) {
             send = send || function() { node.send.apply(node, arguments); };
             done = done || function(err) { if (err) node.error(err, msg); };
 
-            performRead(msg, send, done);
+            // Reject concurrent input-driven reads. The protocol queue (#56)
+            // already serialises sendCommand, but a flood of injects would
+            // still queue an unbounded backlog; explicit drop with feedback
+            // is better UX. Polling sets isReading too — see below. (#77)
+            if (node.isReading) {
+                node.warn("Skipping read - previous read still in progress");
+                done();
+                return;
+            }
+            node.isReading = true;
+            performRead(msg, send, function(err) {
+                node.isReading = false;
+                done(err);
+            });
         });
 
         /**
@@ -304,8 +317,12 @@ module.exports = function(RED) {
                 }, (err) => {
                     node.isReading = false;
                     if (err) {
-                        node.warn(`Polling error: ${err.message}`);
-                        // Don't stop polling on error
+                        // Route polling failures through node.error so Catch
+                        // nodes fire (#77). Polling intentionally continues
+                        // on error — transient timeouts shouldn't stop the
+                        // schedule. The user can wire a Catch + delay/disable
+                        // flow if they want backoff.
+                        node.error(err, msg);
                     }
                 });
             }, intervalMs);

--- a/test/read-node.test.js
+++ b/test/read-node.test.js
@@ -678,6 +678,83 @@ describe("GoodWe Read Node", function () {
         });
     });
 
+    describe("Polling errors route through node.error (#77)", function () {
+
+        it("polling failure invokes node.error so Catch nodes fire", function (done) {
+            mockReadRuntimeData.mockRejectedValue(new Error("simulated polling failure"));
+            const flow = createReadFlow({ polling: 1 });
+
+            helper.load([configNode, readNode], flow, function () {
+                const n1 = helper.getNode("n1");
+
+                // Capture the node.error invocations.
+                let errCalls = 0;
+                let lastErr;
+                const origError = n1.error.bind(n1);
+                n1.error = function(err, msg) {
+                    errCalls++;
+                    lastErr = err;
+                    return origError(err, msg);
+                };
+
+                // Wait for the first polling tick (interval is 1s).
+                setTimeout(() => {
+                    try {
+                        expect(errCalls).toBeGreaterThan(0);
+                        expect(lastErr).toBeDefined();
+                        expect(lastErr.message).toBe("simulated polling failure");
+                        mockReadRuntimeData.mockResolvedValue(MOCK_ET_RUNTIME_DATA); // restore
+                        done();
+                    } catch (e) {
+                        done(e);
+                    }
+                }, 1300);
+            });
+        });
+    });
+
+    describe("Input-time concurrency guard (#77)", function () {
+
+        it("rejects a second input while a first is in flight", function (done) {
+            // Make the first read slow so the second arrives while inflight.
+            let first = true;
+            mockReadRuntimeData.mockImplementation(() => {
+                if (first) {
+                    first = false;
+                    return new Promise(r => setTimeout(() => r(MOCK_ET_RUNTIME_DATA), 200));
+                }
+                return Promise.resolve(MOCK_ET_RUNTIME_DATA);
+            });
+
+            const flow = createReadFlow();
+            helper.load([configNode, readNode], flow, function () {
+                const n1 = helper.getNode("n1");
+                const n2 = helper.getNode("n2");
+
+                let warns = 0;
+                const origWarn = n1.warn.bind(n1);
+                n1.warn = function(msg) { warns++; return origWarn(msg); };
+
+                let outputs = 0;
+                n2.on("input", () => { outputs++; });
+
+                n1.receive({ payload: true });
+                n1.receive({ payload: true }); // arrives during first's 200ms wait
+
+                setTimeout(() => {
+                    try {
+                        expect(warns).toBeGreaterThanOrEqual(1); // second was dropped with a warn
+                        expect(outputs).toBe(1);                  // only first produced output
+                        mockReadRuntimeData.mockReset().mockResolvedValue(MOCK_ET_RUNTIME_DATA);
+                        done();
+                    } catch (e) {
+                        done(e);
+                    }
+                }, 500);
+            });
+        });
+    });
+
     describe("Error Handling", function () {
 
         it("should handle read errors gracefully", function (done) {


### PR DESCRIPTION
## Summary
Closes #77 (low/error-handling). Two fixes in `nodes/read.js` polling:

1. **Polling errors were `node.warn`'d, never `node.error`'d** — Catch nodes wired to the read node didn't see polling failures. Replace with `node.error(err, msg)`. Polling cadence still continues on error (transient timeouts shouldn't break the schedule; user can wire Catch + delay/disable for backoff).

2. **`isReading` guard only covered polling, not input** — a flood of inject messages into a polling node could overlap reads. With #56's protocol queue, sendCommand is already serialised, but the worker would queue unbounded. Apply the guard at `node.on(\"input\")` too — drop the second concurrent read with `node.warn` for immediate feedback.

## Test plan
- [x] `npm test` — 336 pass (+2)
- [x] `npm run lint` — clean
- [ ] CI green on 4 Node versions
- [ ] Post-merge CI green on main

## Self-review
- **Quality**: same `isReading` guard reused at both sites.
- **Architecture**: belt-and-suspenders with #56's queue; user feedback over silent queueing.
- **Security**: prevents flood-of-injects from queueing unbounded.
- **Error handling**: core fix — polling failures now fire Catch nodes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)