### PR TITLE
Surface discovery diagnostics + explicit bind/listening (#78)

### DIFF
--- a/lib/protocol.js
+++ b/lib/protocol.js
@@ -766,6 +766,15 @@ function discoverInverters(options = {}) {
         }
 
         const discoveredInverters = [];
+        // Diagnostic counters (#78). Attached as a non-enumerable property
+        // on the resolved array so callers that ignore them still see a
+        // plain Array shape.
+        const diagnostics = {
+            nonLocalSubnet: 0,
+            invalidFrame: 0,
+            parseFailures: 0
+        };
+
         const socket = dgram.createSocket("udp4");
 
         let cleanedUp = false;
@@ -783,9 +792,19 @@ function discoverInverters(options = {}) {
             }
         };
 
+        const resolveWithDiagnostics = () => {
+            Object.defineProperty(discoveredInverters, "diagnostics", {
+                value: diagnostics,
+                enumerable: false,
+                configurable: false,
+                writable: false
+            });
+            resolve(discoveredInverters);
+        };
+
         const timeoutId = setTimeout(() => {
             cleanup();
-            resolve(discoveredInverters);
+            resolveWithDiagnostics();
         }, timeout);
 
         socket.on("error", (err) => {
@@ -800,7 +819,7 @@ function discoverInverters(options = {}) {
                 // unless the caller explicitly opted out. AA55 has no auth, so
                 // any LAN host that knows the protocol can advertise itself.
                 if (!acceptAnySource && !isLocalSubnet(rinfo.address)) {
-                    // Drop silently — tracking rejected sources is #78's scope.
+                    diagnostics.nonLocalSubnet++;
                     return;
                 }
                 // (2) Validate AA55 framing (magic bytes + length + 16-bit
@@ -809,6 +828,7 @@ function discoverInverters(options = {}) {
                 // command so we only need structural validity here.
                 const validation = modbus.validateAA55Response(msg);
                 if (!validation.valid) {
+                    diagnostics.invalidFrame++;
                     return;
                 }
                 const inverter = parseDiscoveryResponse(msg, rinfo.address);
@@ -819,11 +839,18 @@ function discoverInverters(options = {}) {
                     }
                 }
             } catch (err) {
-                // Ignore parsing errors and continue listening
+                // Continue listening but track the failure for diagnostics (#78).
+                diagnostics.parseFailures++;
             }
         });
 
-        socket.bind(() => {
+        // Use explicit listening/error events instead of bind(callback).
+        // bind() only invokes its callback on success — if the socket can't
+        // bind (e.g. port already in use during a second discovery), the
+        // callback never fires and we'd time out with empty results. With
+        // the on("error") handler above, bind failures already reject; this
+        // makes the intent explicit (#78).
+        socket.once("listening", () => {
             socket.setBroadcast(true);
             socket.send(
                 modbus.AA55_COMMANDS.DISCOVERY,
@@ -838,6 +865,7 @@ function discoverInverters(options = {}) {
                 }
             );
         });
+        socket.bind();
     });
 }
 

--- a/test/connectivity.test.js
+++ b/test/connectivity.test.js
@@ -771,6 +771,29 @@ describe("discovery helper functions", () => {
         });
     });
 
+    describe("discovery diagnostics (#78)", () => {
+        const { discoverInverters } = require("../lib/protocol.js");
+
+        it("attaches a diagnostics object to the resolved array", async () => {
+            const result = await discoverInverters({ timeout: 100 });
+            expect(Array.isArray(result)).toBe(true);
+            expect(result.diagnostics).toEqual({
+                nonLocalSubnet: 0,
+                invalidFrame: 0,
+                parseFailures: 0
+            });
+        });
+
+        it("diagnostics is non-enumerable (Array shape preserved)", async () => {
+            const result = await discoverInverters({ timeout: 100 });
+            // JSON serialisation should not include the diagnostics field —
+            // callers that didn't know about it continue to see a plain Array.
+            expect(JSON.stringify(result)).toBe("[]");
+            // It is still readable directly.
+            expect(typeof result.diagnostics).toBe("object");
+        });
+    });
+
     describe("broadcast address validation (#76)", () => {
         const { isPrivateBroadcast, discoverInverters } = require("../lib/protocol.js");
 


### PR DESCRIPTION
## Summary
Closes #78 (low/error-handling). `discoverInverters` silently dropped malformed packets, non-local-subnet responders, and parser exceptions — there was no way to surface \"scan saw 5 spoofed responses\" or \"12 broken frames\" to the user.

## Changes
- Track diagnostic counters during discovery:
  - `nonLocalSubnet` — responses dropped by #61's filter
  - `invalidFrame` — AA55 validation failures
  - `parseFailures` — parser exceptions caught silently
- Attach as a **non-enumerable** `diagnostics` property on the resolved Array. Callers that ignore it still see a plain Array (JSON serialisation unchanged); callers that read `result.diagnostics` get the counts.
- Replace `socket.bind(callback)` with explicit `socket.once(\"listening\", ...)` then `socket.bind()`. Makes the bind-error path explicit.

## Test plan
- [x] `npm test` — 338 pass (+2)
- [x] `npm run lint` — clean
- [ ] CI green on 4 Node versions
- [ ] Post-merge CI green on main

## Self-review
- **Quality**: counters incremented inline at the existing drop points; no new code paths.
- **Architecture**: zero API break thanks to non-enumerable property.
- **Security**: n/a (diagnostics are passive).
- **Error handling**: parse failures now counted; explicit listening event surfaces bind errors clearly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)