### PR TITLE
Clean up JSDoc gaps and refactor parseDeviceInfo (#79)

### DIFF
--- a/lib/protocol.js
+++ b/lib/protocol.js
@@ -475,12 +475,19 @@ class ProtocolHandler extends EventEmitter {
             );
         }
 
-        // Default: Modbus RTU over UDP
-        return modbus.createRtuReadRequest(
-            this._commAddr,
-            this._familyConfig.registerStart,
-            this._familyConfig.registerCount
-        );
+        // Modbus RTU over UDP — explicit check rather than fall-through so a
+        // typo in this.config.protocol surfaces instead of silently routing
+        // through the RTU codec (#79).
+        if (this.config.protocol === "udp") {
+            return modbus.createRtuReadRequest(
+                this._commAddr,
+                this._familyConfig.registerStart,
+                this._familyConfig.registerCount
+            );
+        }
+        const err = new Error(`Unsupported protocol: ${this.config.protocol}`);
+        err.code = "INVALID_CONFIG";
+        throw err;
     }
 
     /**
@@ -516,14 +523,19 @@ class ProtocolHandler extends EventEmitter {
             return modbus.extractTcpPayload(response);
         }
 
-        // Modbus RTU over UDP
-        const validation = modbus.validateRtuResponse(response, 0x03, this._familyConfig.registerCount);
-        if (!validation.valid) {
-            const err = new Error(`Invalid Modbus RTU response: ${validation.error}`);
-            err.code = "PROTOCOL_ERROR";
-            throw err;
+        // Modbus RTU over UDP — explicit check (see #79 / _buildReadCommand).
+        if (this.config.protocol === "udp") {
+            const validation = modbus.validateRtuResponse(response, 0x03, this._familyConfig.registerCount);
+            if (!validation.valid) {
+                const err = new Error(`Invalid Modbus RTU response: ${validation.error}`);
+                err.code = "PROTOCOL_ERROR";
+                throw err;
+            }
+            return modbus.extractRtuPayload(response);
         }
-        return modbus.extractRtuPayload(response);
+        const err = new Error(`Unsupported protocol: ${this.config.protocol}`);
+        err.code = "INVALID_CONFIG";
+        throw err;
     }
 
     /**
@@ -596,55 +608,37 @@ class ProtocolHandler extends EventEmitter {
 }
 
 /**
+ * AA55 device-info payload layout. ASCII fields are read in order via a
+ * shared loop below; trailing fixed-width binary fields are handled inline.
+ * Offsets/lengths are bytes into the extracted payload (post-AA55 header).
+ */
+const DEVICE_INFO_ASCII_FIELDS = [
+    { name: "model_name",    off: 0,  len: 10 },
+    { name: "serial_number", off: 10, len: 16 },
+    { name: "firmware",      off: 26, len: 6  },
+    { name: "arm_firmware",  off: 32, len: 6  },
+    { name: "dsp1_version",  off: 38, len: 6  },
+    { name: "dsp2_version",  off: 44, len: 6  }
+];
+
+/**
  * Parse device info from AA55 response payload.
- * Layout based on the GoodWe AA55 device info response format.
+ * Layout based on the GoodWe AA55 device info response format. Each field
+ * is parsed only when the payload is long enough to contain it, so short
+ * responses degrade gracefully into a partial info object.
  *
- * @param {Buffer} payload - Extracted AA55 payload
+ * @param {Buffer} payload - Extracted AA55 payload (header/checksum stripped)
  * @returns {Object} Parsed device info
  */
 function parseDeviceInfo(payload) {
     const info = {};
-
-    // Model name: bytes 0-9 (10 bytes ASCII)
-    if (payload.length >= 10) {
-        info.model_name = payload.slice(0, 10).toString("ascii").replace(/\0/g, "").trim();
+    for (const { name, off, len } of DEVICE_INFO_ASCII_FIELDS) {
+        if (payload.length >= off + len) {
+            info[name] = payload.slice(off, off + len).toString("ascii").replace(/\0/g, "").trim();
+        }
     }
-
-    // Serial number: bytes 10-25 (16 bytes ASCII)
-    if (payload.length >= 26) {
-        info.serial_number = payload.slice(10, 26).toString("ascii").replace(/\0/g, "").trim();
-    }
-
-    // Firmware version: bytes 26-31 (6 bytes ASCII)
-    if (payload.length >= 32) {
-        info.firmware = payload.slice(26, 32).toString("ascii").replace(/\0/g, "").trim();
-    }
-
-    // ARM firmware version: bytes 32-37 (6 bytes ASCII)
-    if (payload.length >= 38) {
-        info.arm_firmware = payload.slice(32, 38).toString("ascii").replace(/\0/g, "").trim();
-    }
-
-    // DSP1 version: bytes 38-43 (6 bytes ASCII)
-    if (payload.length >= 44) {
-        info.dsp1_version = payload.slice(38, 44).toString("ascii").replace(/\0/g, "").trim();
-    }
-
-    // DSP2 version: bytes 44-49 (6 bytes ASCII)
-    if (payload.length >= 50) {
-        info.dsp2_version = payload.slice(44, 50).toString("ascii").replace(/\0/g, "").trim();
-    }
-
-    // Rated power: bytes 50-51 (uint16 BE, Watts)
-    if (payload.length >= 52) {
-        info.rated_power = payload.readUInt16BE(50);
-    }
-
-    // AC output type: byte 52 (0=single phase, 1=three phase)
-    if (payload.length >= 53) {
-        info.ac_output_type = payload.readUInt8(52);
-    }
-
+    if (payload.length >= 52) info.rated_power = payload.readUInt16BE(50);  // uint16 BE, Watts
+    if (payload.length >= 53) info.ac_output_type = payload.readUInt8(52);  // 0=single phase, 1=three phase
     return info;
 }
 

--- a/nodes/read.js
+++ b/nodes/read.js
@@ -18,10 +18,14 @@ module.exports = function(RED) {
     "use strict";
 
     /**
-     * Format runtime data based on output format setting
-     * @param {Object} data - Raw runtime data
-     * @param {string} format - Output format (flat/categorized/array)
-     * @param {Array} sensorFilter - Optional list of sensor IDs to include
+     * Format runtime data based on output format setting.
+     * @param {Object} data - Raw runtime data (sensor id → value)
+     * @param {string} format - Output format ("flat" | "categorized" | "array")
+     * @param {Array<string>|null} sensorFilter - Optional sensor IDs to include
+     *   (others are dropped). Pass null/empty to include every sensor.
+     * @param {string} family - Inverter family code. Drives the sensor
+     *   metadata lookup used by the "categorized" and "array" formats; ignored
+     *   by "flat". Defaults to "ET" if falsy.
      * @returns {Object|Array} Formatted data
      */
     function formatRuntimeData(data, format, sensorFilter, family) {
@@ -51,9 +55,12 @@ module.exports = function(RED) {
     }
 
     /**
-     * Format data into categorized groups
-     * @param {Object} data - Runtime data
-     * @returns {Object} Categorized data
+     * Format data into categorized groups (pv / battery / grid / ups / status).
+     * @param {Object} data - Runtime data (sensor id → value)
+     * @param {Object} sensorMetadata - Sensor metadata map from
+     *   `lib/node-helpers.getSensorMetadata(family)`, used to derive each
+     *   sensor's category.
+     * @returns {Object} Categorized data; empty categories are stripped.
      */
     function formatCategorized(data, sensorMetadata) {
         const categorized = {
@@ -88,9 +95,13 @@ module.exports = function(RED) {
     }
 
     /**
-     * Format data into array with metadata
-     * @param {Object} data - Runtime data
-     * @returns {Array} Array of sensor objects with metadata
+     * Format data into an array with per-sensor metadata.
+     * @param {Object} data - Runtime data (sensor id → value)
+     * @param {Object} sensorMetadata - Sensor metadata map from
+     *   `lib/node-helpers.getSensorMetadata(family)`, used to attach `name`,
+     *   `unit`, and `kind` to each entry. Sensors not in the map get defaults
+     *   (`name: <id>`, `unit: ""`, `kind: "UNKNOWN"`).
+     * @returns {Array<{id, value, name, unit, kind}>}
      */
     function formatArray(data, sensorMetadata) {
         const array = [];


### PR DESCRIPTION
## Summary
Closes #79 (low/quality). Three small cleanups from the grouped issue.

## Changes
1. **`nodes/read.js`** — JSDoc gaps filled on `formatRuntimeData` (the `family` arg), `formatCategorized` and `formatArray` (the `sensorMetadata` arg). Concrete types + behaviour notes.
2. **`lib/protocol.js parseDeviceInfo`** — six repeated slice/toString/replace blocks collapsed into a declarative `DEVICE_INFO_ASCII_FIELDS` table + loop. Binary trailing fields stay inline.
3. **`lib/protocol.js _extractPayload` & `_buildReadCommand`** — the \"Modbus RTU over UDP\" branch was unconditional fall-through; a typo in `protocol` silently routed through the RTU codec. Added explicit `if (protocol === \"udp\")` checks; throw `INVALID_CONFIG` for anything else.

## Test plan
- [x] `npm test` — 338 pass (no behaviour change for valid inputs)
- [x] `npm run lint` — clean
- [ ] CI green on 4 Node versions
- [ ] Post-merge CI green on main

## Self-review
- **Quality**: 6 repeated blocks → 1 declarative table + loop; JSDoc gaps filled.
- **Architecture**: explicit protocol matching shrinks the silent-fall-through surface.
- **Security**: minor — typos in protocol no longer silently use RTU.
- **Error handling**: new `INVALID_CONFIG` paths for unknown protocol values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)