### PR TITLE
Add DT vpv4/ipv4 for 50K KMT 4-MPPT support (#82)

### DIFF
--- a/lib/sensors.js
+++ b/lib/sensors.js
@@ -240,13 +240,19 @@ const DT_REGISTER_COUNT = 73;
 const DT_SENSORS = [
     { id: "timestamp",           offset: 30100, type: "Timestamp",  size: 6,  kind: null,      unit: "",    name: "Timestamp" },
 
-    // PV1-3
+    // PV1-4. PV4 (registers 30109/30110) is populated on 4-MPPT DT
+    // inverters such as the 50K KMT (KS-MT); ported from upstream
+    // marcelblijleven/goodwe ced4b96 (#82). Inverters with fewer MPPT
+    // inputs simply return 0 for vpv4/ipv4 and downstream callers can
+    // filter them out via the goodwe-read sensor filter.
     { id: "vpv1",                offset: 30103, type: "Voltage",    size: 2,  kind: Kind.PV,   unit: "V",   name: "PV1 Voltage" },
     { id: "ipv1",                offset: 30104, type: "Current",    size: 2,  kind: Kind.PV,   unit: "A",   name: "PV1 Current" },
     { id: "vpv2",                offset: 30105, type: "Voltage",    size: 2,  kind: Kind.PV,   unit: "V",   name: "PV2 Voltage" },
     { id: "ipv2",                offset: 30106, type: "Current",    size: 2,  kind: Kind.PV,   unit: "A",   name: "PV2 Current" },
     { id: "vpv3",                offset: 30107, type: "Voltage",    size: 2,  kind: Kind.PV,   unit: "V",   name: "PV3 Voltage" },
     { id: "ipv3",                offset: 30108, type: "Current",    size: 2,  kind: Kind.PV,   unit: "A",   name: "PV3 Current" },
+    { id: "vpv4",                offset: 30109, type: "Voltage",    size: 2,  kind: Kind.PV,   unit: "V",   name: "PV4 Voltage" },
+    { id: "ipv4",                offset: 30110, type: "Current",    size: 2,  kind: Kind.PV,   unit: "A",   name: "PV4 Current" },
 
     // AC line-to-line
     { id: "vline1",              offset: 30115, type: "Voltage",    size: 2,  kind: Kind.AC,   unit: "V",   name: "On-grid L1-L2 Voltage" },

--- a/test/sensors.test.js
+++ b/test/sensors.test.js
@@ -385,6 +385,20 @@ describe("parseSensorData", () => {
         expect(result.e_day).toBeCloseTo(15.2);
     });
 
+    test("parses DT vpv4/ipv4 for 4-MPPT KMT inverters (#82)", () => {
+        const buf = Buffer.alloc(146);
+
+        // vpv4 at register 30109, byte offset = (30109-30100)*2 = 18
+        buf.writeUInt16BE(3950, 18); // 395.0V
+        // ipv4 at register 30110, byte offset = (30110-30100)*2 = 20
+        buf.writeUInt16BE(125, 20);  // 12.5A
+
+        const result = parseSensorData(DT_SENSORS, buf, DT_REGISTER_START);
+
+        expect(result.vpv4).toBeCloseTo(395.0);
+        expect(result.ipv4).toBeCloseTo(12.5);
+    });
+
     test("parses ES sensor data from byte-offset buffer", () => {
         const buf = Buffer.alloc(93);
 


### PR DESCRIPTION
## Summary
Partial backport of #82 (upstream sync). Adds `vpv4`/`ipv4` registers to the DT family sensor map for 50K KMT (KS-MT) 4-MPPT inverters. Ported from upstream `marcelblijleven/goodwe` commit `ced4b96` (Mar 29 2026).

## Context
- The \"KMT\" model tag was already added to `FAMILY_TAGS.DT` in #57, so discovery already classifies these inverters as DT.
- This change exposes the additional PV-string sensors.
- Both registers (30109, 30110) fall within the existing DT read window (`DT_REGISTER_COUNT=73`, range 30100-30172) — no protocol-layer change required.
- 2/3-MPPT inverters return 0 for vpv4/ipv4; users can filter via `goodwe-read` sensor filter.

## Test plan
- [x] `npm test` — 339 pass (+1, the new DT 4-MPPT parse test)
- [x] `npm run lint` — clean
- [ ] CI green on 4 Node versions
- [ ] Post-merge CI green on main

## Self-review
- **Quality**: 2 register entries; pattern matches existing PV1-3 layout; inline comment with upstream commit reference.
- **Architecture**: zero protocol change; sensor data flows through the same `parseSensorData` pipeline.
- **Security**: n/a.
- **Error handling**: n/a — missing bytes already return null in `parseSensorData`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)