### PR TITLE
Document macOS Local Network permission for discovery (#82)

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,8 @@ The discover node finds GoodWe inverters on the local network using UDP broadcas
 }
 ```
 
+**macOS note:** Recent macOS versions (Sonoma / Sequoia onward) prompt for **Local Network** permission the first time a process binds a UDP socket and broadcasts on the LAN. If discovery returns empty results on macOS, check **System Settings → Privacy & Security → Local Network** and grant access to the runtime that runs Node-RED (Terminal, the Node-RED app, or whatever launches the `node` process). Without this permission the OS silently drops the discovery probe — there's no error to surface. Equivalent to upstream marcelblijleven/goodwe `14d4571`.
+
 ### Error Handling
 
 All nodes provide enhanced error messages with actionable suggestions:

--- a/nodes/discover.html
+++ b/nodes/discover.html
@@ -138,6 +138,9 @@ msg.payload = {
 };
 return msg;</pre>
 
+    <h3>Troubleshooting</h3>
+    <p><strong>macOS:</strong> Sonoma and later prompt for <em>Local Network</em> permission before a process can broadcast UDP on the LAN. If discovery returns empty on macOS, grant the runtime that launches Node-RED access in <em>System Settings → Privacy & Security → Local Network</em>. The OS drops the probe silently without it, so no error surfaces.</p>
+
     <h3>Status Updates</h3>
     <p>The node provides visual status feedback during discovery:</p>
     <ul>


### PR DESCRIPTION
## Summary
Partial backport of #82. Adds a troubleshooting note about macOS Local Network permission to README and the discover-node HTML help. Equivalent to upstream `marcelblijleven/goodwe` `14d4571`.

## Why
Sonoma+ silently drops UDP broadcasts from processes lacking Local Network permission. The Node-RED user sees empty discovery results with no error and no obvious next step. Two short notes cover the symptom + the fix.

## Test plan
- [x] `npm test` — 339 pass (docs-only)
- [x] `npm run lint` — clean
- [ ] CI green on 4 Node versions
- [ ] Post-merge CI green on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)