### PR TITLE
CI tune-up: fix dependabot + cancel superseded PR runs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,20 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
 # https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "npm"
+    directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      dev-dependencies:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,13 @@ on:
   pull_request:
     branches: [ main ]
 
+# Cancel superseded runs on the same PR — saves CI minutes when a fixup
+# commit lands while the previous run is still in flight. Push events on
+# main are kept since each commit is a real merge.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Two minor improvements found while validating the GitHub Actions setup. The npm install path itself is already well-tuned — `actions/setup-node@v6` with `cache: 'npm'` is the recommended approach for `npm ci`.

## Changes

### 1. `.github/dependabot.yml` — was broken
`package-ecosystem: \"\"` is empty, so Dependabot wasn't actually watching anything. The bumps that landed earlier (#43–#54) must have come from elsewhere. Now:
- `npm` watcher, weekly, max 5 open PRs
- Group dev-dep minor/patch bumps so we don't get spammed
- Second entry for `github-actions` so action pins stay current

### 2. `.github/workflows/ci.yml` — concurrency cancellation
Add a `concurrency` group keyed by workflow+ref that cancels superseded runs **on pull_request events only**. Saves CI minutes when a fixup commit lands while the previous run is still in flight. Push events on `main` are not cancelled — each merge commit deserves its own definitive result.

## Rejected optimizations (why)
- **Direct `node_modules` caching** — slower than `~/.npm` cache because of mtime / native binary handling.
- **`.eslintcache` / `.jest_cache`** — runs are already ~10s; not worth it.
- **Splitting lint into its own job** — would be 5 parallel jobs vs 4 (no net speedup, more workflow surface).

## Test plan
- [x] yaml syntactically valid (no parse errors locally)
- [ ] CI green on the PR itself (the workflow is the test)
- [ ] Verify concurrency: pushing a fixup commit on this PR should cancel the in-flight previous run

🤖 Generated with [Claude Code](https://claude.com/claude-code)