### PR TITLE
chore(ci): drop unused Codecov upload step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,14 +42,7 @@ jobs:
       
     - name: Run tests
       run: npm test -- --coverage
-      
-    - name: Upload coverage to Codecov
-      if: contains(fromJson('["20.x","22.x","24.x"]'), matrix.node-version)
-      uses: codecov/codecov-action@v6
-      with:
-        files: ./coverage/lcov.info
-        fail_ci_if_error: false
-        
+
     - name: Archive test results
       if: always()
       uses: actions/upload-artifact@v7

--- a/test/README.md
+++ b/test/README.md
@@ -272,7 +272,7 @@ GitHub Actions runs every push and PR against `main`:
 - Matrix: Node 20.x / 22.x / 24.x / 26.x
 - `fail-fast: false` (one version failing doesn't abort the others)
 - Steps: `npm ci` → `npm run lint` → `npm test -- --coverage`
-- Coverage uploaded to Codecov on the 20.x/22.x/24.x legs (skip 26.x to avoid 4 identical uploads)
+- Coverage is generated locally per job (Jest's threshold in `jest.config.js` is the gate); per-job artifacts are uploaded as `test-results-<node-version>` with 7-day retention
 - `concurrency` group cancels superseded PR runs
 
 Current workflow: `.github/workflows/ci.yml`.


### PR DESCRIPTION
## Summary

Removes the Codecov upload from `ci.yml`. Nothing in the repo consumed the data:

- No `codecov.yml` policy
- No badge in `README.md`
- No required-check gate (the action had `fail_ci_if_error: false`)
- The coverage *gate* is enforced by Jest's `coverageThreshold` in `jest.config.js` — that's what blocks merges on a regression, not Codecov

Bonus cleanup: the conditional `if: contains(fromJson('["20.x","22.x","24.x"]'), matrix.node-version)` was a stale guard. Node 26 was added to the matrix later but never added to the upload list, and re-uploading identical lcov from 3 of 4 jobs was redundant anyway.

## Diff

- `.github/workflows/ci.yml`: remove the "Upload coverage to Codecov" step
- `test/README.md`: update the CI-integration bullet (Codecov line → coverage-as-artefact line)

The existing `actions/upload-artifact` step still archives `coverage/` per Node version with 7-day retention, so the lcov data is still inspectable if anyone wants it.

## Test plan

- [x] `npm test -- --coverage` locally — 303/303 green, threshold met
- [ ] CI passes on Node 20/22/24/26 with the modified workflow
- [ ] Copilot review

🤖 Generated with [Claude Code](https://claude.com/claude-code)