### PR TITLE
fix(docs): make README links to non-shipped files absolute

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A Node-RED port of the [marcelblijleven/goodwe](https://github.com/marcelblijlev
 - Discover inverters on the local network via UDP broadcast
 - Support for ET, EH, BT, BH, ES, EM, BP, DT, MS, D-NS, XS families
 - Shared configuration node for managing multiple inverters
-- Source-IP filtering and frame validation against LAN spoofing (see [SECURITY.md](./SECURITY.md))
+- Source-IP filtering and frame validation against LAN spoofing (see [SECURITY.md](https://github.com/pkot/node-red-contrib-goodwe/blob/main/SECURITY.md))
 
 ## Installation
 
@@ -65,15 +65,15 @@ ET, EH, BT, BH, GEH (hybrid / Modbus) · DT, MS, D-NS, XS, KMT (grid-tie / Modbu
 
 GoodWe AA55 and Modbus framing use error-detection codes, not authentication. Anyone on the same L2 segment with the public protocol spec can fabricate a syntactically valid frame. This package mitigates the most common spoofing vectors (subnet filtering on discovery, frame validation, request serialization) but doesn't make the protocol authenticated.
 
-Full trust model + what to do about it: [`SECURITY.md`](./SECURITY.md).
+Full trust model + what to do about it: [`SECURITY.md`](https://github.com/pkot/node-red-contrib-goodwe/blob/main/SECURITY.md).
 
 ## Development & contributing
 
 - Node.js ≥ 20.19, npm ≥ 6
 - Clone, `npm install`, `npm test`
-- Test framework and patterns: [`test/README.md`](./test/README.md)
-- Workflow, code conventions, commit format: [`CONTRIBUTING.md`](./CONTRIBUTING.md)
-- For AI assistants working on the repo: [`AGENTS.md`](./AGENTS.md)
+- Test framework and patterns: [`test/README.md`](https://github.com/pkot/node-red-contrib-goodwe/blob/main/test/README.md)
+- Workflow, code conventions, commit format: [`CONTRIBUTING.md`](https://github.com/pkot/node-red-contrib-goodwe/blob/main/CONTRIBUTING.md)
+- For AI assistants working on the repo: [`AGENTS.md`](https://github.com/pkot/node-red-contrib-goodwe/blob/main/AGENTS.md)
 
 ## License
 

--- a/nodes/README.md
+++ b/nodes/README.md
@@ -149,7 +149,7 @@ UDP-broadcast discovery of GoodWe inverters on the local network.
 **Node settings:**
 - **Name** — display name
 - **Timeout** — discovery window in ms (default 5000, UI minimum 1000, max 300000). Flow-imported configs are floored at 100 ms by the runtime as a defensive parse, but the editor input rejects anything under 1000.
-- **Broadcast Address** — default `255.255.255.255` (limited broadcast — stays on the local segment). Directed broadcasts like `192.168.1.255` are accepted; non-private addresses are rejected for safety (see [SECURITY.md](../SECURITY.md)).
+- **Broadcast Address** — default `255.255.255.255` (limited broadcast — stays on the local segment). Directed broadcasts like `192.168.1.255` are accepted; non-private addresses are rejected for safety (see [SECURITY.md](https://github.com/pkot/node-red-contrib-goodwe/blob/main/SECURITY.md)).
 
 **Input:** any message triggers discovery.
 


### PR DESCRIPTION
## Problem

The npm tarball only ships `nodes/`, `lib/`, `examples/`, `README.md`, `LICENSE` (per the `files` array in `package.json`). Relative links from `README.md` to anything outside that set — `SECURITY.md`, `test/README.md`, `CONTRIBUTING.md`, `AGENTS.md` — render as 404s on npmjs.com, because npm renders the README in isolation against the tarball.

## Fix

Six links switched from relative to `https://github.com/pkot/node-red-contrib-goodwe/blob/main/<path>`:

**Root `README.md`:**
- ❶ `[SECURITY.md](./SECURITY.md)` in Features bullet
- ❷ `[SECURITY.md](./SECURITY.md)` in Security section
- ❸ `[test/README.md](./test/README.md)` in Development
- ❹ `[CONTRIBUTING.md](./CONTRIBUTING.md)` in Development
- ❺ `[AGENTS.md](./AGENTS.md)` in Development

**`nodes/README.md`:**
- ❻ `[SECURITY.md](../SECURITY.md)` in the discover-node broadcast note

Links to files that **are** in the tarball stay relative:
- `nodes/README.md`, `examples/README.md`, `LICENSE` (from root)
- `../README.md`, `../lib/errors.js` (from `nodes/README.md`)
- The three JSON files + `../nodes/README.md` (from `examples/README.md`)

## Verification

`grep -nE '\]\(\.\.?/' README.md nodes/README.md examples/README.md lib/README.md` after the change returns only links into the tarball.

## Test plan

- [x] No code touched; no tests affected
- [ ] CI green on Node 20/22/24/26
- [ ] Copilot review

🤖 Generated with [Claude Code](https://claude.com/claude-code)