### PR TITLE
chore(ci): drop unused Archive test results step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,13 +42,3 @@ jobs:
       
     - name: Run tests
       run: npm test -- --coverage
-
-    - name: Archive test results
-      if: always()
-      uses: actions/upload-artifact@v7
-      with:
-        name: test-results-${{ matrix.node-version }}
-        path: |
-          coverage/
-          *.log
-        retention-days: 7

--- a/test/README.md
+++ b/test/README.md
@@ -272,7 +272,7 @@ GitHub Actions runs every push and PR against `main`:
 - Matrix: Node 20.x / 22.x / 24.x / 26.x
 - `fail-fast: false` (one version failing doesn't abort the others)
 - Steps: `npm ci` → `npm run lint` → `npm test -- --coverage`
-- Coverage is generated locally per job (Jest's threshold in `jest.config.js` is the gate); per-job artifacts are uploaded as `test-results-<node-version>` with 7-day retention
+- The merge gate is Jest's threshold in `jest.config.js` — a regression below 70% on any metric fails the build directly in the Actions log
 - `concurrency` group cancels superseded PR runs
 
 Current workflow: `.github/workflows/ci.yml`.


### PR DESCRIPTION
## Summary

Removes the `Archive test results` step from `ci.yml`. Same logic as #124's Codecov removal — data with no consumer.

## Why

- The `*.log` glob matched zero files (nothing in the repo writes `.log`).
- The `coverage/` artefact has gone undownloaded across ~30 PRs.
- Both diagnostic surfaces this was meant to serve — test failures and coverage-threshold breaches — already print verbatim in the GitHub Actions log.

Jest's `coverageThreshold` in `jest.config.js` remains the merge gate; threshold regressions fail the build with the exact file + percentage in the log.

## Diff

- `.github/workflows/ci.yml`: removes the 9-line archive step
- `test/README.md`: updates the CI bullet to reflect the new flow (no artefact upload; Jest threshold is the gate)

## Test plan

- [x] No code touched
- [ ] CI green on Node 20/22/24/26 with the trimmed workflow
- [ ] Copilot review

🤖 Generated with [Claude Code](https://claude.com/claude-code)